### PR TITLE
UI: Support Reusable Apple Pay Button

### DIFF
--- a/FrameExample-iOS/FrameExample-iOS/ContentView.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentView.swift
@@ -27,6 +27,10 @@ struct ContentView: View {
     @State var showRefundsView: Bool = false
     @State var showSubscriptionPhases: Bool = false
     @State var showOnboardingSheet: Bool = false
+    @State var applePayResult: String? = nil
+
+    // Replace with your Apple Pay merchant ID registered in your entitlements
+    let applePayMerchantId: String = "merchant.com.yourapp"
     
     var body: some View {
         VStack {
@@ -60,8 +64,30 @@ struct ContentView: View {
             }
             Spacer()
             cartButton
+            // Apple Pay button — only visible on devices that support Apple Pay
+            FrameApplePayButton(
+                amount: 35000,
+                currency: "usd",
+                merchantId: applePayMerchantId
+            ) { result in
+                switch result {
+                case .success(let chargeIntent):
+                    applePayResult = "Payment succeeded! ChargeIntent: \(chargeIntent.id)"
+                case .failure(let error):
+                    applePayResult = "Payment failed: \(error.localizedDescription)"
+                }
+            }
+            .padding(.horizontal)
         }
         .padding()
+        .alert("Apple Pay Result", isPresented: Binding(
+            get: { applePayResult != nil },
+            set: { if !$0 { applePayResult = nil } }
+        )) {
+            Button("OK") { applePayResult = nil }
+        } message: {
+            Text(applePayResult ?? "")
+        }
         .sheet(isPresented: $showOnboardingSheet, content: {
 //            An existing account Id can be added here to onboarding an existing user.
 //            OnboardingContainerView(accountId: "ENTER_TEST_ACCOUNT_ID", requiredCapabilities: [])

--- a/FrameExample-iOS/FrameExample-iOS/ContentView.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentView.swift
@@ -42,6 +42,23 @@ struct ContentView: View {
                 .multilineTextAlignment(.center)
                 .padding()
             ScrollView {
+                cartButton
+                // Apple Pay button — only visible on devices that support Apple Pay
+                FrameApplePayButton(
+                    amount: 35000,
+                    currency: "usd",
+                    owner: .customer("ENTER_TEST_CUSTOMER_ID"),
+                    merchantId: applePayMerchantId
+                ) { result in
+                    switch result {
+                    case .success(let chargeIntent):
+                        applePayResult = "Payment succeeded! ChargeIntent: \(chargeIntent.id)"
+                    case .failure(let error):
+                        applePayResult = "Payment failed: \(error.localizedDescription)"
+                    }
+                }
+                .padding(.horizontal)
+                Divider()
                 onboardingButton
                 allCustomersButton
                     .disabled(viewModel.customers.isEmpty)
@@ -62,22 +79,6 @@ struct ContentView: View {
                     .disabled(viewModel.subscriptionPhases.isEmpty)
                     .opacity(viewModel.subscriptionPhases.isEmpty ? 0.3 : 1)
             }
-            Spacer()
-            cartButton
-            // Apple Pay button — only visible on devices that support Apple Pay
-            FrameApplePayButton(
-                amount: 35000,
-                currency: "usd",
-                merchantId: applePayMerchantId
-            ) { result in
-                switch result {
-                case .success(let chargeIntent):
-                    applePayResult = "Payment succeeded! ChargeIntent: \(chargeIntent.id)"
-                case .failure(let error):
-                    applePayResult = "Payment failed: \(error.localizedDescription)"
-                }
-            }
-            .padding(.horizontal)
         }
         .padding()
         .alert("Apple Pay Result", isPresented: Binding(
@@ -285,7 +286,7 @@ struct ContentView: View {
         Button {
             self.showCheckoutView = true
         } label: {
-            Text("Checkout")
+            Text("Show Checkout")
                 .font(.headline)
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, alignment: .center)

--- a/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
@@ -19,8 +19,10 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
     @Published var refunds: [FrameObjects.Refund] = []
     
     init() {
-        // Note: To use this SDK, you must add your sandbox secret key here.
-        FrameNetworking.shared.initializeWithAPIKey("INSERT_SANDBOX_KEY_HERE", debugMode: true)
+        // Note: To use this SDK, you must add your sandbox publishable and secret keys here.
+        FrameNetworking.shared.initializeWithAPIKey("ENTER_SECRET_KEY_HERE",
+                                                    publishableKey: "ENTER_PUBLISHABLE_KEY_HERE",
+                                                    debugMode: true)
         
         Task {
             await self.getCustomers()

--- a/FrameExample-iOS/FrameExample-iOS/FrameExample_iOS.entitlements
+++ b/FrameExample-iOS/FrameExample-iOS/FrameExample_iOS.entitlements
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+	</array>
+</dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The Frame iOS SDK gives you everything you need to build a polished payment expe
 - [Apple Pay](#apple-pay)
 - [Frame Onboarding](#frame-onboarding)
 - [Examples](#examples)
-- [React Native](#react-native)
 - [Privacy](#privacy)
 - [Support](#support)
 
@@ -83,7 +82,7 @@ import Frame_iOS
 @main
 struct MyApp: App {
     init() {
-        FrameNetworking.shared.initializeWithAPIKey("sk_your_secret_key_here")
+        FrameNetworking.shared.initializeWithAPIKey("sk_your_secret_key_here", debugMode: false)
     }
 
     var body: some Scene {
@@ -138,15 +137,22 @@ All API classes are stateless — call them directly without creating an instanc
 | Class | Description |
 |-------|-------------|
 | `CustomersAPI` | Create, retrieve, update, delete, and search customers |
+| `CustomerIdentityAPI` | Customer identity verification |
 | `PaymentMethodsAPI` | Add and manage payment methods |
 | `ChargeIntentsAPI` | Create and manage charge intents |
+| `ApplePayAPI` | Apple Pay token processing |
 | `SubscriptionsAPI` | Subscription lifecycle management |
+| `SubscriptionPhasesAPI` | Subscription phase management |
 | `InvoicesAPI` | Invoice retrieval and operations |
+| `InvoiceLineItemsAPI` | Invoice line item management |
 | `ProductsAPI` | Product catalog management |
+| `ProductPhasesAPI` | Product phase management |
 | `RefundsAPI` | Initiate and track refunds |
 | `DisputesAPI` | Dispute retrieval and management |
 | `AccountsAPI` | Account details and configuration |
 | `CapabilitiesAPI` | Account capability verification |
+| `TermsOfServiceAPI` | Terms of service management |
+| `ConfigurationAPI` | SDK configuration |
 | `PhoneOTPVerificationAPI` | Phone number OTP verification |
 | `ThreeDSecureVerificationsAPI` | 3D Secure payment verification |
 | `GeocomplianceAPI` | Location compliance checking |
@@ -207,15 +213,15 @@ A customizable cart and checkout component. Conform your item model to `FrameCar
 ```swift
 struct CartItem: FrameCartItem {
     var id: String
-    var name: String
-    var price: Int
-    var quantity: Int
+    var imageURL: String
+    var title: String
+    var amountInCents: Int
 }
 
 FrameCartView(
-    items: cartItems,
-    shippingCost: 599,
-    customerId: customer.id
+    customer: customer,
+    cartItems: cartItems,
+    shippingAmountInCents: 599
 )
 ```
 
@@ -271,7 +277,7 @@ import Frame_iOS
 FrameApplePayButton(
     amount: 4999,                              // amount in cents ($49.99)
     currency: "usd",
-    customerId: "cus_123",                     // optional Frame customer ID
+    owner: .customer("cus_123"),               // .customer or .account
     merchantId: "merchant.com.yourcompany.appname"
 ) { result in
     switch result {
@@ -283,12 +289,12 @@ FrameApplePayButton(
 }
 ```
 
-Use `accountId` instead of `customerId` if your integration is account-based:
+Use `.account` instead of `.customer` if your integration is account-based:
 
 ```swift
 FrameApplePayButton(
     amount: 4999,
-    accountId: "acc_456",
+    owner: .account("acc_456"),
     merchantId: "merchant.com.yourcompany.appname"
 ) { result in ... }
 ```
@@ -300,6 +306,7 @@ The button type and style can be configured to match your UI:
 ```swift
 FrameApplePayButton(
     amount: 4999,
+    owner: .customer("cus_123"),
     merchantId: "merchant.com.yourcompany.appname",
     buttonType: .pay,        // .buy (default), .pay, .checkout, .plain, etc.
     buttonStyle: .white      // .black (default), .white, .whiteOutline
@@ -466,66 +473,6 @@ The `FrameExample-iOS` app in this repository demonstrates:
 - Listing customers, payment methods, subscriptions, charge intents, and refunds
 
 To run the example app, open `FrameExample-iOS/FrameExample-iOS.xcodeproj` in Xcode and run the target on a simulator or device.
-
----
-
-## React Native
-
-The Frame iOS SDK can be bridged into a React Native project through a native module.
-
-### 1. Create a Bridge File
-
-Inside the `ios/` folder of your React Native project, create a new Swift file (e.g. `FrameBridge.swift`):
-
-```swift
-import Foundation
-import Frame_iOS
-
-@objc(FrameBridge)
-class FrameBridge: NSObject {
-
-    @objc static func requiresMainQueueSetup() -> Bool {
-        return true
-    }
-
-    @objc func initialize(_ apiKey: String) {
-        FrameNetworking.shared.initializeWithAPIKey(apiKey)
-    }
-
-    @objc func getCustomers(
-        _ resolve: @escaping RCTPromiseResolveBlock,
-        rejecter reject: @escaping RCTPromiseRejectBlock
-    ) {
-        Task {
-            do {
-                let customers = try await CustomersAPI.getCustomers()
-                resolve(customers)
-            } catch {
-                reject("GET_CUSTOMERS_ERROR", error.localizedDescription, error)
-            }
-        }
-    }
-}
-```
-
-### 2. Register the Module
-
-Ensure the module is registered in your `AppDelegate`. With React Native 0.60+, autolinking handles this automatically.
-
-### 3. Use from JavaScript
-
-```javascript
-import { NativeModules } from 'react-native';
-const { FrameBridge } = NativeModules;
-
-// Initialize
-FrameBridge.initialize('sk_your_secret_key_here');
-
-// Call APIs
-FrameBridge.getCustomers()
-  .then(customers => console.log(customers))
-  .catch(error => console.error(error));
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Frame iOS SDK gives you everything you need to build a polished payment expe
 - [Features](#features)
 - [API Reference](#api-reference)
 - [UI Components](#ui-components)
+- [Apple Pay](#apple-pay)
 - [Frame Onboarding](#frame-onboarding)
 - [Examples](#examples)
 - [React Native](#react-native)
@@ -114,7 +115,7 @@ CustomersAPI.getCustomers { customers in
 ## Features
 
 ### Prebuilt UI Components
-Drop-in SwiftUI views for checkout and payment card entry that handle the full payment flow, including card encryption.
+Drop-in SwiftUI views for checkout, card entry, and Apple Pay that handle the full payment flow, including card encryption.
 
 ### Full API Client
 Static, initialization-less API classes covering every Frame endpoint. All methods support both `async/await` and completion handler patterns.
@@ -227,6 +228,117 @@ EncryptedPaymentCardInput { encryptedCard in
     // encryptedCard is ready to send to your server
 }
 ```
+
+---
+
+## Apple Pay
+
+`FrameApplePayButton` is a drop-in SwiftUI view that presents a native Apple Pay sheet, submits the encrypted payment token to Frame, and returns a `ChargeIntent` via a callback — all without requiring any additional configuration beyond a merchant ID.
+
+### Xcode Setup (required)
+
+Apple Pay requires two things in your Xcode project before the button will function:
+
+#### 1. Add the Apple Pay Capability
+
+1. Open your project in Xcode and select your **app target** (not the framework or package).
+2. Go to **Signing & Capabilities**.
+3. Click **+ Capability** and add **Apple Pay**.
+4. Under the Apple Pay capability, click **+** and enter your merchant identifier (e.g. `merchant.com.yourcompany.appname`).
+
+> If you haven't created a merchant ID yet, go to [developer.apple.com → Certificates, Identifiers & Profiles → Identifiers → Merchant IDs](https://developer.apple.com/account/resources/identifiers/list/merchant) and create one first.
+
+#### 2. Verify Your Entitlements File
+
+After adding the capability, Xcode automatically adds an entitlements file (e.g. `YourApp.entitlements`) to your project. Confirm it contains your merchant ID:
+
+```xml
+<key>com.apple.developer.in-app-payments</key>
+<array>
+    <string>merchant.com.yourcompany.appname</string>
+</array>
+```
+
+> The SDK itself does **not** require this entitlement — only your host app does.
+
+### Usage
+
+Drop `FrameApplePayButton` anywhere in your SwiftUI view hierarchy. It automatically renders nothing on devices that do not support Apple Pay (no need to guard it yourself).
+
+```swift
+import Frame_iOS
+
+FrameApplePayButton(
+    amount: 4999,                              // amount in cents ($49.99)
+    currency: "usd",
+    customerId: "cus_123",                     // optional Frame customer ID
+    merchantId: "merchant.com.yourcompany.appname"
+) { result in
+    switch result {
+    case .success(let chargeIntent):
+        print("Payment succeeded: \(chargeIntent.id)")
+    case .failure(let error):
+        print("Payment failed: \(error.localizedDescription)")
+    }
+}
+```
+
+Use `accountId` instead of `customerId` if your integration is account-based:
+
+```swift
+FrameApplePayButton(
+    amount: 4999,
+    accountId: "acc_456",
+    merchantId: "merchant.com.yourcompany.appname"
+) { result in ... }
+```
+
+### Button Customization
+
+The button type and style can be configured to match your UI:
+
+```swift
+FrameApplePayButton(
+    amount: 4999,
+    merchantId: "merchant.com.yourcompany.appname",
+    buttonType: .pay,        // .buy (default), .pay, .checkout, .plain, etc.
+    buttonStyle: .white      // .black (default), .white, .whiteOutline
+) { result in ... }
+```
+
+See [`PKPaymentButtonType`](https://developer.apple.com/documentation/passkit/pkpaymentbuttontype) and [`PKPaymentButtonStyle`](https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle) for all available options.
+
+### Using Apple Pay inside FrameCheckoutView
+
+Pass a `merchantId` to `FrameCheckoutView` to show an Apple Pay button at the top of the checkout sheet:
+
+```swift
+FrameCheckoutView(
+    customerId: customer.id,
+    paymentAmount: 4999,
+    merchantId: "merchant.com.yourcompany.appname"
+) { chargeIntent in
+    // Handle completed charge intent
+}
+```
+
+If `merchantId` is omitted or empty, the Apple Pay button is hidden and only the card entry form is shown.
+
+### Testing
+
+Apple Pay **requires a physical device** — it cannot be tested on the Simulator. To test in the Frame sandbox:
+
+1. Use a device with a card added to Apple Wallet.
+2. Initialize the SDK with your sandbox key (`sk_sandbox_...`).
+3. The Frame backend returns synthetic card details in sandbox mode — no real charge is made.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Button does not appear | Device has no cards in Wallet, or Apple Pay capability is missing from the app target |
+| "Missing entitlement" error at runtime | The merchant ID in your entitlements file doesn't match the one passed to `FrameApplePayButton` |
+| Payment sheet appears but authorization fails | SDK not initialized with `FrameNetworking.shared.initializeWithAPIKey(...)` before presenting the button |
 
 ---
 
@@ -349,6 +461,7 @@ The `FrameExample-iOS` app in this repository demonstrates:
 
 - Initializing the SDK and making API calls
 - Using `FrameCartView` and `FrameCheckoutView`
+- Processing payments with `FrameApplePayButton`
 - Triggering a full onboarding flow with `OnboardingContainerView`
 - Listing customers, payment methods, subscriptions, charge intents, and refunds
 

--- a/Sources/Frame/Networking/ChargeIntents/ChargeIntentsObjects.swift
+++ b/Sources/Frame/Networking/ChargeIntents/ChargeIntentsObjects.swift
@@ -29,6 +29,7 @@ extension FrameObjects {
         public let currency: String
         public let latestCharge: LatestCharge?
         public let customer: FrameObjects.Customer?
+        public let account: FrameObjects.Account? 
         public let paymentMethod: FrameObjects.PaymentMethod?
         public let shipping: FrameObjects.BillingAddress?
         public let status: FrameObjects.ChargeIntentStatus
@@ -41,11 +42,12 @@ extension FrameObjects {
         public let updated: Int
         public let livemode: Bool
         
-        public init(id: String, currency: String, latestCharge: FrameObjects.LatestCharge? = nil, customer: FrameObjects.Customer? = nil, paymentMethod: FrameObjects.PaymentMethod? = nil, shipping: FrameObjects.BillingAddress, status: FrameObjects.ChargeIntentStatus, description: String? = nil, authorizationMode: FrameObjects.AuthorizationMode, failureDescription: String? = nil, object: String, amount: Int, created: Int, updated: Int, livemode: Bool) {
+        public init(id: String, currency: String, latestCharge: FrameObjects.LatestCharge? = nil, customer: FrameObjects.Customer? = nil, account: FrameObjects.Account? = nil, paymentMethod: FrameObjects.PaymentMethod? = nil, shipping: FrameObjects.BillingAddress, status: FrameObjects.ChargeIntentStatus, description: String? = nil, authorizationMode: FrameObjects.AuthorizationMode, failureDescription: String? = nil, object: String, amount: Int, created: Int, updated: Int, livemode: Bool) {
             self.id = id
             self.currency = currency
             self.latestCharge = latestCharge
             self.customer = customer
+            self.account = account
             self.paymentMethod = paymentMethod
             self.shipping = shipping
             self.status = status
@@ -60,7 +62,7 @@ extension FrameObjects {
         }
         
         public enum CodingKeys: String, CodingKey {
-            case id, currency, customer, shipping, status, description, object, amount, created, livemode, updated
+            case id, currency, customer, shipping, status, description, object, amount, created, livemode, updated, account
             case latestCharge = "latest_charge"
             case paymentMethod = "payment_method"
             case authorizationMode = "authorization_mode"
@@ -81,15 +83,16 @@ extension FrameObjects {
         public let chargeIntent: String
         public let refunded: Bool
         public let failureMessage: String?
-        public  let description: String?
+        public let description: String?
         public let status: FrameObjects.ChargeIntentStatus?
-        public  let paymentMethodDetails: FrameObjects.PaymentMethod?
+        public let paymentMethodDetails: FrameObjects.PaymentMethod?
         public let customer: String?
+        public let account: String?
         public let paymentMethod: String?
         public let amount: Int
         
         public enum CodingKeys: String, CodingKey {
-            case id, currency, created, updated, livemode, captured, disputed, refunded, description, status, customer, amount
+            case id, currency, created, updated, livemode, captured, disputed, refunded, description, status, customer, amount, account
             case amountCaptured = "amount_captured"
             case amountRefunded = "amount_refunded"
             case chargeIntent = "charge_intent"

--- a/Sources/Frame/Networking/ChargeIntents/ChargeIntentsRequests.swift
+++ b/Sources/Frame/Networking/ChargeIntents/ChargeIntentsRequests.swift
@@ -12,6 +12,7 @@ public class ChargeIntentsRequests {
         let amount: Int
         let currency: String
         let customer: String?
+        let account: String? // use instead of customer, not with it.
         let description: String?
         let paymentMethod: String?
         let confirm: Bool
@@ -23,10 +24,11 @@ public class ChargeIntentsRequests {
         var fraudSignals: FraudSignals?
         var sonarSessionId: String?
         
-        public init(amount: Int, currency: String, customer: String? = nil, description: String? = nil, paymentMethod: String? = nil, confirm: Bool, receiptEmail: String? = nil, authorizationMode: FrameObjects.AuthorizationMode? = nil, customerData: CustomerData? = nil, paymentMethodData: PaymentMethodData? = nil) {
+        public init(amount: Int, currency: String, customer: String? = nil, account: String? = nil, description: String? = nil, paymentMethod: String? = nil, confirm: Bool, receiptEmail: String? = nil, authorizationMode: FrameObjects.AuthorizationMode? = nil, customerData: CustomerData? = nil, paymentMethodData: PaymentMethodData? = nil) {
             self.amount = amount
             self.currency = currency
             self.customer = customer
+            self.account = account
             self.description = description
             self.paymentMethod = paymentMethod
             self.confirm = confirm
@@ -37,7 +39,7 @@ public class ChargeIntentsRequests {
         }
         
         public enum CodingKeys: String, CodingKey {
-            case amount, currency, customer, description, confirm
+            case amount, currency, customer, description, confirm, account
             case paymentMethod = "payment_method"
             case receiptEmail = "receipt_email"
             case authorizationMode = "authorization_mode"
@@ -53,15 +55,17 @@ public class ChargeIntentsRequests {
         let amount: Int?
         let currency: String?
         let customer: String?
+        let account: String?
         let description: String?
         let paymentMethod: String?
         let confirm: Bool?
         let receiptEmail: String?
         
-        public init(amount: Int? = nil, currency: String? = nil, customer: String? = nil, description: String? = nil, paymentMethod: String? = nil, confirm: Bool? = nil, receiptEmail: String? = nil) {
+        public init(amount: Int? = nil, currency: String? = nil, customer: String? = nil, account: String? = nil, description: String? = nil, paymentMethod: String? = nil, confirm: Bool? = nil, receiptEmail: String? = nil) {
             self.amount = amount
             self.currency = currency
             self.customer = customer
+            self.account = account
             self.description = description
             self.paymentMethod = paymentMethod
             self.confirm = confirm
@@ -69,7 +73,7 @@ public class ChargeIntentsRequests {
         }
         
         public enum CodingKeys: String, CodingKey {
-            case amount, currency, customer, description, confirm
+            case amount, currency, customer, description, confirm, account
             case paymentMethod = "payment_method"
             case receiptEmail = "receipt_email"
         }

--- a/Sources/Frame/Networking/FrameNetworking.swift
+++ b/Sources/Frame/Networking/FrameNetworking.swift
@@ -24,13 +24,15 @@ public class FrameNetworking: ObservableObject {
     var asyncURLSession: URLSessionProtocol = URLSession.shared
     var urlSession: URLSession = URLSession.shared
     
-    private var apiKey: String = "" // API Key used to authenticate each request - Bearer Token
+    private var apiSecretKey: String = "" // API Key used to authenticate each request - Bearer Token
+    private var apiPublishableKey: String = "" // Publishable key for client-side only endpoints
     private var debugMode: Bool = false // Print API data on task calls.
-    
+
     var isEvervaultConfigured: Bool = false
-    
-    public func initializeWithAPIKey(_ key: String, debugMode: Bool = false) {
-        self.apiKey = key
+
+    public func initializeWithAPIKey(_ key: String, publishableKey: String, debugMode: Bool = false) {
+        self.apiSecretKey = key
+        self.apiPublishableKey = publishableKey
         self.debugMode = debugMode
         
         // Initializes Sift and Sonar Session when the SDK is initialized.
@@ -49,21 +51,22 @@ public class FrameNetworking: ObservableObject {
     }
     
     // Async/Await
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil) async throws -> (Data?, NetworkingError?) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, usePublishableKey: Bool = false) async throws -> (Data?, NetworkingError?) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return (nil, nil) }
-        
+
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = endpoint.httpMethod.rawValue
         if endpoint.httpMethod == .POST || endpoint.httpMethod == .PATCH {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
-        
+
         urlRequest.httpBody = requestBody
         if let queryItems = endpoint.queryItems {
             urlRequest.url?.append(queryItems: queryItems)
         }
-        
-        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let authKey = usePublishableKey && !apiPublishableKey.isEmpty ? apiPublishableKey : apiSecretKey
+        urlRequest.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         if let ipAddress = SiftManager.getIPAddress() {
             urlRequest.setValue(SiftManager.getIPAddress(), forHTTPHeaderField: "ip_address")
@@ -115,7 +118,7 @@ public class FrameNetworking: ObservableObject {
         urlRequest.httpBody = body
         urlRequest.setValue(multipart.contentTypeHeader, forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
-        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(apiSecretKey)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         if let ipAddress = SiftManager.getIPAddress() {
             urlRequest.setValue(SiftManager.getIPAddress(), forHTTPHeaderField: "ip_address")
@@ -142,7 +145,7 @@ public class FrameNetworking: ObservableObject {
     }
     
     // Completion Handler
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, usePublishableKey: Bool = false, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return completion(nil, nil, nil) }
         
         var urlRequest = URLRequest(url: url)
@@ -156,7 +159,8 @@ public class FrameNetworking: ObservableObject {
             urlRequest.url?.append(queryItems: queryItems)
         }
         
-        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let authKey = usePublishableKey && !apiPublishableKey.isEmpty ? apiPublishableKey : apiSecretKey
+        urlRequest.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         
         if let ipAddress = SiftManager.getIPAddress() {
@@ -211,7 +215,7 @@ public class FrameNetworking: ObservableObject {
         urlRequest.httpBody = body
         urlRequest.setValue(multipart.contentTypeHeader, forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
-        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(apiSecretKey)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         
         if let ipAddress = SiftManager.getIPAddress() {

--- a/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
@@ -32,7 +32,7 @@ public class ApplePayAPI {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, usePublishableKey: true)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decoded, error)
         }
@@ -47,7 +47,7 @@ public class ApplePayAPI {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, usePublishableKey: true)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decoded, error)
         }

--- a/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
@@ -1,0 +1,148 @@
+//
+//  ApplePayAPI.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 4/2/25.
+
+import Foundation
+import PassKit
+
+private struct PKPaymentDataJSON: Decodable {
+    let version: String
+    let data: String
+    let signature: String
+    let header: PKPaymentDataHeaderJSON
+
+    struct PKPaymentDataHeaderJSON: Decodable {
+        let ephemeralPublicKey: String
+        let publicKeyHash: String
+        let transactionId: String
+    }
+}
+
+// MARK: - ApplePayAPI
+
+public class ApplePayAPI {
+
+    public static func createPaymentMethodWithCustomerId(
+        from payment: PKPayment,
+        customerId: String? = nil
+    ) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
+        let request = try buildRequest(from: payment, customerId: customerId, accountId: nil)
+        let endpoint = PaymentMethodEndpoints.createPaymentMethod
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
+            return (decoded, error)
+        }
+        return (nil, error)
+    }
+
+    public static func createPaymentMethodWithAccountId(
+        from payment: PKPayment,
+        accountId: String? = nil
+    ) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
+        let request = try buildRequest(from: payment, customerId: nil, accountId: accountId)
+        let endpoint = PaymentMethodEndpoints.createPaymentMethod
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
+            return (decoded, error)
+        }
+        return (nil, error)
+    }
+
+    // MARK: - Request builder
+
+    static func buildRequest(
+        from payment: PKPayment,
+        customerId: String?,
+        accountId: String?
+    ) throws -> ApplePayRequests.CreateApplePayPaymentMethodRequest {
+        // Decode the encrypted payment data JSON from PKPaymentToken
+        let paymentDataJSON = try decodePaymentData(payment.token.paymentData)
+
+        let header = ApplePayRequests.ApplePayPaymentDataHeader(
+            ephemeralPublicKey: paymentDataJSON.header.ephemeralPublicKey,
+            publicKeyHash: paymentDataJSON.header.publicKeyHash,
+            transactionId: paymentDataJSON.header.transactionId
+        )
+
+        let paymentData = ApplePayRequests.ApplePayPaymentData(
+            version: paymentDataJSON.version,
+            data: paymentDataJSON.data,
+            signature: paymentDataJSON.signature,
+            header: header
+        )
+
+        let paymentMethod = ApplePayRequests.ApplePayPaymentMethod(
+            displayName: payment.token.paymentMethod.displayName ?? "",
+            network: payment.token.paymentMethod.network?.rawValue ?? "",
+            type: paymentMethodTypeString(payment.token.paymentMethod.type)
+        )
+
+        let billingContact = buildBillingContact(payment.billingContact)
+
+        let tokenDetails = ApplePayRequests.ApplePayTokenDetails(
+            token: ApplePayRequests.ApplePayToken(
+                paymentData: paymentData,
+                paymentMethod: paymentMethod,
+                transactionIdentifier: payment.token.transactionIdentifier
+            ),
+            billingContact: billingContact
+        )
+
+        let applePayDetails = ApplePayRequests.ApplePayDetails(
+            requestId: UUID().uuidString,
+            payerName: payment.billingContact?.name.map { formatName($0) },
+            payerEmail: payment.billingContact?.emailAddress,
+            details: tokenDetails
+        )
+
+        let wallet = ApplePayRequests.ApplePayWallet(applePay: applePayDetails)
+
+        return ApplePayRequests.CreateApplePayPaymentMethodRequest(
+            wallet: wallet,
+            customer: customerId,
+            account: accountId
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func decodePaymentData(_ data: Data) throws -> PKPaymentDataJSON {
+        do {
+            return try JSONDecoder().decode(PKPaymentDataJSON.self, from: data)
+        } catch {
+            throw NetworkingError.decodingFailed
+        }
+    }
+
+    private static func paymentMethodTypeString(_ type: PKPaymentMethodType) -> String {
+        switch type {
+        case .credit: return "credit"
+        case .debit: return "debit"
+        case .prepaid: return "prepaid"
+        case .store: return "store"
+        default: return "unknown"
+        }
+    }
+
+    private static func buildBillingContact(_ contact: PKContact?) -> ApplePayRequests.ApplePayBillingContact? {
+        guard let contact else { return nil }
+        let postalAddress = contact.postalAddress
+        return ApplePayRequests.ApplePayBillingContact(
+            addressLines: postalAddress.map { [$0.street].filter { !$0.isEmpty } },
+            locality: postalAddress?.city,
+            administrativeArea: postalAddress?.state,
+            postalCode: postalAddress?.postalCode,
+            countryCode: postalAddress?.isoCountryCode
+        )
+    }
+
+    private static func formatName(_ name: PersonNameComponents) -> String {
+        [name.givenName, name.familyName].compactMap { $0 }.joined(separator: " ")
+    }
+}

--- a/Sources/Frame/Networking/PaymentMethods/ApplePayRequests.swift
+++ b/Sources/Frame/Networking/PaymentMethods/ApplePayRequests.swift
@@ -1,0 +1,163 @@
+//
+//  ApplePayRequests.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 4/2/25.
+//
+
+import Foundation
+
+public class ApplePayRequests {
+
+    // MARK: - Top-level request
+
+    public struct CreateApplePayPaymentMethodRequest: Encodable {
+        let type: String = "card"
+        let wallet: ApplePayWallet
+        let customer: String?  // use instead of account
+        let account: String?   // use instead of customer
+
+        public init(wallet: ApplePayWallet, customer: String? = nil, account: String? = nil) {
+            self.wallet = wallet
+            self.customer = customer
+            self.account = account
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type, customer, account
+            case wallet = "_wallet"
+        }
+    }
+
+    // MARK: - Wallet envelope
+
+    public struct ApplePayWallet: Encodable {
+        let type: String = "apple_pay"
+        let applePay: ApplePayDetails
+
+        public init(applePay: ApplePayDetails) {
+            self.applePay = applePay
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case applePay = "apple_pay"
+        }
+    }
+
+    // MARK: - Apple Pay details
+
+    public struct ApplePayDetails: Encodable {
+        let requestId: String
+        let methodName: String = "https://apple.com/apple-pay"
+        let payerName: String?
+        let payerEmail: String?
+        let details: ApplePayTokenDetails
+
+        public init(requestId: String, payerName: String? = nil, payerEmail: String? = nil, details: ApplePayTokenDetails) {
+            self.requestId = requestId
+            self.payerName = payerName
+            self.payerEmail = payerEmail
+            self.details = details
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case requestId = "requestId"
+            case methodName = "methodName"
+            case payerName = "payerName"
+            case payerEmail = "payerEmail"
+            case details
+        }
+    }
+
+    public struct ApplePayTokenDetails: Encodable {
+        let token: ApplePayToken
+        let billingContact: ApplePayBillingContact?
+
+        public init(token: ApplePayToken, billingContact: ApplePayBillingContact? = nil) {
+            self.token = token
+            self.billingContact = billingContact
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case token
+            case billingContact = "billingContact"
+        }
+    }
+
+    // MARK: - Token
+
+    public struct ApplePayToken: Encodable {
+        let paymentData: ApplePayPaymentData
+        let paymentMethod: ApplePayPaymentMethod
+        let transactionIdentifier: String
+
+        public init(paymentData: ApplePayPaymentData, paymentMethod: ApplePayPaymentMethod, transactionIdentifier: String) {
+            self.paymentData = paymentData
+            self.paymentMethod = paymentMethod
+            self.transactionIdentifier = transactionIdentifier
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case paymentData, paymentMethod, transactionIdentifier
+        }
+    }
+
+    public struct ApplePayPaymentData: Encodable {
+        let version: String
+        let data: String
+        let signature: String
+        let header: ApplePayPaymentDataHeader
+
+        public init(version: String, data: String, signature: String, header: ApplePayPaymentDataHeader) {
+            self.version = version
+            self.data = data
+            self.signature = signature
+            self.header = header
+        }
+    }
+
+    public struct ApplePayPaymentDataHeader: Encodable {
+        let ephemeralPublicKey: String
+        let publicKeyHash: String
+        let transactionId: String
+
+        public init(ephemeralPublicKey: String, publicKeyHash: String, transactionId: String) {
+            self.ephemeralPublicKey = ephemeralPublicKey
+            self.publicKeyHash = publicKeyHash
+            self.transactionId = transactionId
+        }
+    }
+
+    public struct ApplePayPaymentMethod: Encodable {
+        let displayName: String
+        let network: String
+        let type: String
+
+        public init(displayName: String, network: String, type: String) {
+            self.displayName = displayName
+            self.network = network
+            self.type = type
+        }
+    }
+
+    // MARK: - Billing contact
+
+    public struct ApplePayBillingContact: Encodable {
+        let addressLines: [String]?
+        let locality: String?
+        let administrativeArea: String?
+        let postalCode: String?
+        let countryCode: String?
+
+        public init(addressLines: [String]? = nil, locality: String? = nil,
+                    administrativeArea: String? = nil, postalCode: String? = nil,
+                    countryCode: String? = nil) {
+            self.addressLines = addressLines
+            self.locality = locality
+            self.administrativeArea = administrativeArea
+            self.postalCode = postalCode
+            self.countryCode = countryCode
+        }
+    }
+}

--- a/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
@@ -9,9 +9,9 @@ import Foundation
 import PassKit
 
 @MainActor
-class FrameApplePayViewModel: NSObject, ObservableObject {
+public class FrameApplePayViewModel: NSObject, ObservableObject {
 
-    enum PaymentMethodOwner {
+    public enum PaymentMethodOwner {
         case customer(String)
         case account(String)
     }
@@ -27,7 +27,7 @@ class FrameApplePayViewModel: NSObject, ObservableObject {
 
     var completion: ((Result<FrameObjects.ChargeIntent, Error>) -> Void)?
 
-    init(amount: Int,
+    public init(amount: Int,
          currency: String,
          owner: PaymentMethodOwner,
          merchantId: String,
@@ -79,7 +79,7 @@ class FrameApplePayViewModel: NSObject, ObservableObject {
 extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
 
     /// Called when the user authorizes payment. Uses the async overload available on iOS 16+.
-    func paymentAuthorizationController(
+    public func paymentAuthorizationController(
         _ controller: PKPaymentAuthorizationController,
         didAuthorizePayment payment: PKPayment
     ) async -> PKPaymentAuthorizationResult {
@@ -143,7 +143,7 @@ extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
         }
     }
 
-    func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
+    public func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
         controller.dismiss()
     }
 }

--- a/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
@@ -1,0 +1,149 @@
+//
+//  FrameApplePayViewModel.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 4/2/25.
+//
+
+import Foundation
+import PassKit
+
+@MainActor
+class FrameApplePayViewModel: NSObject, ObservableObject {
+
+    enum PaymentMethodOwner {
+        case customer(String)
+        case account(String)
+    }
+
+    // MARK: - Published state
+
+    @Published var isProcessing: Bool = false
+
+    let amount: Int
+    let currency: String
+    let owner: PaymentMethodOwner
+    let merchantId: String
+
+    var completion: ((Result<FrameObjects.ChargeIntent, Error>) -> Void)?
+
+    init(amount: Int,
+         currency: String,
+         owner: PaymentMethodOwner,
+         merchantId: String,
+         completion: ((Result<FrameObjects.ChargeIntent, Error>) -> Void)? = nil) {
+        self.amount = amount
+        self.currency = currency
+        self.owner = owner
+        self.merchantId = merchantId
+        self.completion = completion
+    }
+
+    /// Returns true if the device can make Apple Pay payments with at least one of the supported networks.
+    static func canMakePayments() -> Bool {
+        PKPaymentAuthorizationController.canMakePayments(usingNetworks: supportedNetworks)
+    }
+
+    /// Presents the Apple Pay sheet. Must be called on the main thread.
+    func presentApplePay() {
+        let request = buildPaymentRequest()
+        let controller = PKPaymentAuthorizationController(paymentRequest: request)
+        controller.delegate = self
+        controller.present()
+    }
+
+    private static let supportedNetworks: [PKPaymentNetwork] = [
+        .visa, .masterCard, .amex, .discover, .JCB
+    ]
+
+    private func buildPaymentRequest() -> PKPaymentRequest {
+        let request = PKPaymentRequest()
+        request.merchantIdentifier = merchantId
+        request.supportedNetworks = Self.supportedNetworks
+        request.merchantCapabilities = .threeDSecure
+        request.countryCode = "US"
+        request.currencyCode = currency.uppercased()
+        request.requiredBillingContactFields = [.postalAddress, .name, .emailAddress]
+        request.paymentSummaryItems = [
+            PKPaymentSummaryItem(
+                label: "Total",
+                amount: NSDecimalNumber(value: Double(amount) / 100.0)
+            )
+        ]
+        return request
+    }
+}
+
+// MARK: - PKPaymentAuthorizationControllerDelegate
+
+extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
+
+    /// Called when the user authorizes payment. Uses the async overload available on iOS 16+.
+    func paymentAuthorizationController(
+        _ controller: PKPaymentAuthorizationController,
+        didAuthorizePayment payment: PKPayment
+    ) async -> PKPaymentAuthorizationResult {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            // 1. Create a Frame PaymentMethod from the Apple Pay token
+            let (paymentMethod, methodError): (FrameObjects.PaymentMethod?, NetworkingError?)
+            switch owner {
+            case .customer(let customerId):
+                (paymentMethod, methodError) = try await ApplePayAPI.createPaymentMethodWithCustomerId(
+                    from: payment,
+                    customerId: customerId
+                )
+            case .account(let accountId):
+                (paymentMethod, methodError) = try await ApplePayAPI.createPaymentMethodWithAccountId(
+                    from: payment,
+                    accountId: accountId
+                )
+            }
+            guard let paymentMethodId = paymentMethod?.id else {
+                completion?(.failure(methodError ?? NetworkingError.unknownError))
+                return PKPaymentAuthorizationResult(status: .failure, errors: nil)
+            }
+
+            // 2. Create and confirm a ChargeIntent with the payment method
+            let request: ChargeIntentsRequests.CreateChargeIntentRequest
+            switch owner {
+            case .customer(let customerId):
+                request = ChargeIntentsRequests.CreateChargeIntentRequest(
+                    amount: amount,
+                    currency: currency,
+                    customer: customerId,
+                    paymentMethod: paymentMethodId,
+                    confirm: true,
+                    authorizationMode: .automatic
+                )
+            case .account(let accountId):
+                request = ChargeIntentsRequests.CreateChargeIntentRequest(
+                    amount: amount,
+                    currency: currency,
+                    account: accountId,
+                    paymentMethod: paymentMethodId,
+                    confirm: true,
+                    authorizationMode: .automatic
+                )
+            }
+            let (chargeIntent, chargeError) = try await ChargeIntentsAPI.createChargeIntent(request: request)
+
+            if let chargeIntent {
+                completion?(.success(chargeIntent))
+                return PKPaymentAuthorizationResult(status: .success, errors: nil)
+            } else {
+                completion?(.failure(chargeError ?? NetworkingError.unknownError))
+                return PKPaymentAuthorizationResult(status: .failure, errors: nil)
+            }
+        } catch {
+            completion?(.failure(error))
+            return PKPaymentAuthorizationResult(status: .failure, errors: nil)
+        }
+    }
+
+    func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
+        controller.dismiss()
+    }
+}

--- a/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
@@ -24,22 +24,39 @@ class FrameCheckoutViewModel: ObservableObject {
     @Published var cardData = PaymentCardData()
     
     var customerId: String?
-    var amount: Int = 0
-    
-    func loadCustomerPaymentMethods(customerId: String?, amount: Int, forTesting: Bool = false) async {
-        self.amount = amount
-        
-        guard let customerId else { return }
+    var amount: Int
+    var merchantId: String
+
+    private var applePayViewModel: FrameApplePayViewModel?
+
+    init(customerId: String?, amount: Int, merchantId: String = "") {
         self.customerId = customerId
-        
+        self.amount = amount
+        self.merchantId = merchantId
+    }
+
+    func loadCustomerPaymentMethods(forTesting: Bool = false) async {
+        guard let customerId else { return }
+
         let customer = try? await CustomersAPI.getCustomerWith(customerId: customerId, forTesting: forTesting).0
         self.customerPaymentOptions = customer?.paymentMethods
         self.customerName = customer?.name ?? ""
         self.customerEmail = customer?.email ?? ""
     }
     
-    //TODO: Integrate for Apple Pay and Google Pay
-    func payWithApplePay() { }
+    func payWithApplePay(completion: @escaping (Result<FrameObjects.ChargeIntent, Error>) -> Void) {
+        guard !merchantId.isEmpty else { return }
+        applePayViewModel = FrameApplePayViewModel(
+            amount: amount,
+            currency: "usd",
+            owner: customerId.map { .customer($0) } ?? .customer(""),
+            merchantId: merchantId,
+            completion: completion
+        )
+        applePayViewModel?.presentApplePay()
+    }
+
+    //TODO: Integrate Google Pay
     func payWithGooglePay() { }
     
     func checkoutWithSelectedPaymentMethod(saveMethod: Bool) async throws -> FrameObjects.ChargeIntent? {

--- a/Sources/Frame/Views/Elements/PKPaymentButtonWrapper.swift
+++ b/Sources/Frame/Views/Elements/PKPaymentButtonWrapper.swift
@@ -1,0 +1,41 @@
+//
+//  PKPaymentButtonWrapper.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 4/2/25.
+//
+
+import SwiftUI
+import PassKit
+
+struct PKPaymentButtonWrapper: UIViewRepresentable {
+    var buttonType: PKPaymentButtonType
+    var buttonStyle: PKPaymentButtonStyle
+    var action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeUIView(context: Context) -> PKPaymentButton {
+        let button = PKPaymentButton(paymentButtonType: buttonType, paymentButtonStyle: buttonStyle)
+        button.addTarget(context.coordinator, action: #selector(Coordinator.tapped), for: .touchUpInside)
+        return button
+    }
+
+    func updateUIView(_ uiView: PKPaymentButton, context: Context) {
+        context.coordinator.action = action
+    }
+
+    class Coordinator: NSObject {
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func tapped() {
+            action()
+        }
+    }
+}

--- a/Sources/Frame/Views/FrameApplePayButton.swift
+++ b/Sources/Frame/Views/FrameApplePayButton.swift
@@ -1,0 +1,74 @@
+//
+//  FrameApplePayButton.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 4/2/25.
+
+import SwiftUI
+import PassKit
+
+public struct FrameApplePayButton: View {
+
+    // MARK: - Configuration
+
+    let amount: Int
+    let currency: String
+    let owner: FrameApplePayViewModel.PaymentMethodOwner
+    let merchantId: String
+    let buttonType: PKPaymentButtonType
+    let buttonStyle: PKPaymentButtonStyle
+    let completion: (Result<FrameObjects.ChargeIntent, Error>) -> Void
+
+    @StateObject private var viewModel: FrameApplePayViewModel
+
+    public init(amount: Int,
+                currency: String = "usd",
+                owner: FrameApplePayViewModel.PaymentMethodOwner,
+                merchantId: String,
+                buttonType: PKPaymentButtonType = .buy,
+                buttonStyle: PKPaymentButtonStyle = .black,
+                completion: @escaping (Result<FrameObjects.ChargeIntent, Error>) -> Void) {
+        self.amount = amount
+        self.currency = currency
+        self.owner = owner
+        self.merchantId = merchantId
+        self.buttonType = buttonType
+        self.buttonStyle = buttonStyle
+        self.completion = completion
+
+        _viewModel = StateObject(wrappedValue: FrameApplePayViewModel(
+            amount: amount,
+            currency: currency,
+            owner: owner,
+            merchantId: merchantId,
+            completion: completion
+        ))
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        if FrameApplePayViewModel.canMakePayments() {
+            PKPaymentButtonWrapper(
+                buttonType: buttonType,
+                buttonStyle: buttonStyle
+            ) {
+                viewModel.presentApplePay()
+            }
+            .frame(height: 50)
+            .disabled(viewModel.isProcessing)
+        }
+        // Renders nothing if Apple Pay is unavailable on this device
+    }
+}
+
+#Preview {
+    FrameApplePayButton(
+        amount: 15000,
+        owner: .customer("cus_preview"),
+        merchantId: "merchant.com.yourapp"
+    ) { result in
+        print(result)
+    }
+    .padding()
+}

--- a/Sources/Frame/Views/FrameCartView.swift
+++ b/Sources/Frame/Views/FrameCartView.swift
@@ -85,7 +85,7 @@ public struct FrameCartView: View {
                 checkoutButton
             }
             .navigationDestination(isPresented: $continueToCheckout) {
-                FrameCheckoutView(customerId: customer?.id, paymentAmount: cartViewModel.finalTotal) { chargeIntent in
+                FrameCheckoutView(customerId: customer?.id, paymentAmount: cartViewModel.finalTotal, merchantId: "test.merchant.id") { chargeIntent in
                     self.dismiss()
                 }
                 .toolbar(.hidden)

--- a/Sources/Frame/Views/FrameCheckoutView.swift
+++ b/Sources/Frame/Views/FrameCheckoutView.swift
@@ -10,7 +10,7 @@ import EvervaultInputs
 
 public struct FrameCheckoutView: View {
     @Environment(\.dismiss) var dismiss
-    @StateObject var checkoutViewModel: FrameCheckoutViewModel = FrameCheckoutViewModel()
+    @StateObject var checkoutViewModel: FrameCheckoutViewModel
     
     @State private var rotationAngle = 0.0
     @State var showLoadingState: Bool = false
@@ -20,15 +20,22 @@ public struct FrameCheckoutView: View {
     
     let customerId: String?
     let paymentAmount: Int
-    
+    let merchantId: String
+
     var colors: [Color] = [Color.white, Color.white.opacity(0.3)]
-    
+
     var checkoutCallback: (FrameObjects.ChargeIntent) -> ()
     
-    public init(customerId: String?, paymentAmount: Int, checkoutCallback: @escaping (FrameObjects.ChargeIntent) -> ()) {
+    public init(customerId: String?, paymentAmount: Int, merchantId: String = "", checkoutCallback: @escaping (FrameObjects.ChargeIntent) -> ()) {
         self.customerId = customerId
         self.paymentAmount = paymentAmount
+        self.merchantId = merchantId
         self.checkoutCallback = checkoutCallback
+        _checkoutViewModel = StateObject(wrappedValue: FrameCheckoutViewModel(
+            customerId: customerId,
+            amount: paymentAmount,
+            merchantId: merchantId
+        ))
     }
     
     public var body: some View {
@@ -36,8 +43,10 @@ public struct FrameCheckoutView: View {
             topHeaderBar
             Divider()
             ScrollView {
-//                paymentButtons - Hiding Apple & Google Pay buttons until we add the implementation
-//                paymentDivider
+                if !merchantId.isEmpty {
+                    paymentButtons
+                    paymentDivider
+                }
                 if checkoutViewModel.customerPaymentOptions != nil {
                     existingPaymentCardScroll
                         .padding([.leading, .bottom])
@@ -52,7 +61,7 @@ public struct FrameCheckoutView: View {
             }
         }
         .task {
-            await checkoutViewModel.loadCustomerPaymentMethods(customerId: customerId, amount: paymentAmount)
+            await checkoutViewModel.loadCustomerPaymentMethods()
         }
         .sheet(isPresented: $isShowingPicker) {
             CountryPickerSheet(
@@ -99,12 +108,17 @@ public struct FrameCheckoutView: View {
     
     @ViewBuilder
     var paymentButtons: some View {
-        FramePaymentButton(blackButton: useBlackButtons, paymentOption: .apple) {
-            checkoutViewModel.payWithApplePay()
+        FrameApplePayButton(
+            amount: paymentAmount,
+            customerId: customerId,
+            merchantId: merchantId
+        ) { result in
+            if case .success(let chargeIntent) = result {
+                checkoutCallback(chargeIntent)
+                dismiss()
+            }
         }
-        FramePaymentButton(blackButton: useBlackButtons, paymentOption: .google) {
-            checkoutViewModel.payWithGooglePay()
-        }
+        .padding(.horizontal)
     }
     
     var existingPaymentCardScroll: some View {

--- a/Sources/Frame/Views/FrameCheckoutView.swift
+++ b/Sources/Frame/Views/FrameCheckoutView.swift
@@ -44,7 +44,7 @@ public struct FrameCheckoutView: View {
             Divider()
             ScrollView {
                 if !merchantId.isEmpty {
-                    paymentButtons
+                    applePayButton
                     paymentDivider
                 }
                 if checkoutViewModel.customerPaymentOptions != nil {
@@ -103,16 +103,14 @@ public struct FrameCheckoutView: View {
             Rectangle().fill(.gray.opacity(0.3))
                 .frame(height: 1)
         }
-        .padding(.horizontal)
+        .padding()
     }
     
     @ViewBuilder
-    var paymentButtons: some View {
-        FrameApplePayButton(
-            amount: paymentAmount,
-            customerId: customerId,
-            merchantId: merchantId
-        ) { result in
+    var applePayButton: some View {
+        FrameApplePayButton(amount: paymentAmount,
+                            owner: .customer(customerId ?? ""),
+                            merchantId: merchantId) { result in
             if case .success(let chargeIntent) = result {
                 checkoutCallback(chargeIntent)
                 dismiss()

--- a/Tests/Frame-iOSTests/CheckoutViewModelTests.swift
+++ b/Tests/Frame-iOSTests/CheckoutViewModelTests.swift
@@ -19,22 +19,24 @@ final class CheckoutViewModelTests: XCTestCase {
         FrameNetworking.shared.asyncURLSession = session
         
         // Test with invalid customer ID
-        let viewModel = FrameCheckoutViewModel()
-        await viewModel.loadCustomerPaymentMethods(customerId: "", amount: 100, forTesting: true)
+        let viewModel = FrameCheckoutViewModel(customerId: "", amount: 100)
+        await viewModel.loadCustomerPaymentMethods()
         XCTAssertNil(viewModel.customerPaymentOptions)
         
         // Test with valid customer ID with no payment methods
-        await viewModel.loadCustomerPaymentMethods(customerId: "1", amount: 100, forTesting: true)
-        XCTAssertNil(viewModel.customerPaymentOptions)
+        let viewModelTwo = FrameCheckoutViewModel(customerId: "1", amount: 100)
+        await viewModelTwo.loadCustomerPaymentMethods()
+        XCTAssertNil(viewModelTwo.customerPaymentOptions)
         
         // Test with valid customer ID with payment method
         let paymentMethod = FrameObjects.PaymentMethod(id: "1", type: .card, object: "", created: 0, updated: 0, livemode: false, status: .active)
         let customer = FrameObjects.Customer(id: "1", livemode: false, name: "Tester", paymentMethods: [paymentMethod])
         
         session.data = try? JSONEncoder().encode(customer)
-        await viewModel.loadCustomerPaymentMethods(customerId: "1", amount: 100, forTesting: true)
-        XCTAssertNotNil(viewModel.customerPaymentOptions)
-        XCTAssertEqual(viewModel.customerPaymentOptions?.first?.id, "1")
+        let viewModelThree = FrameCheckoutViewModel(customerId: "1", amount: 100)
+        await viewModelThree.loadCustomerPaymentMethods()
+        XCTAssertNotNil(viewModelThree.customerPaymentOptions)
+        XCTAssertEqual(viewModelThree.customerPaymentOptions?.first?.id, "1")
     }
     
     @MainActor func testCreatePaymentMethod() async {
@@ -55,7 +57,7 @@ final class CheckoutViewModelTests: XCTestCase {
         
         // Test with no customer country or customer Zip Code
         session.data = try? JSONEncoder().encode(FrameObjects.PaymentMethod(id: "1", type: .card, object: "", created: 0, updated: 0, livemode: true, card: paymentCard, status: .active))
-        let viewModel = FrameCheckoutViewModel()
+        let viewModel = FrameCheckoutViewModel(customerId: "", amount: 100)
         viewModel.customerZipCode = ""
         let firstMethod = try? await viewModel.createPaymentMethod()
         XCTAssertNil(firstMethod?.paymentId)

--- a/Tests/Frame-iOSTests/FrameNetworkingTests.swift
+++ b/Tests/Frame-iOSTests/FrameNetworkingTests.swift
@@ -8,31 +8,36 @@
 import XCTest
 @testable import Frame
 
-// Mock URLSessionDataTask
-class MockURLSessionDataTask: URLSessionDataTask, @unchecked Sendable {
-    private let completion: () -> Void
-    
-    init(completion: @escaping () -> Void) {
-        self.completion = completion
+// Mock URLProtocol for completion handler tests
+class MockURLProtocol: URLProtocol {
+    static var mockData: Data?
+    static var mockResponse: URLResponse?
+    static var mockError: Error?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if let error = MockURLProtocol.mockError {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        if let response = MockURLProtocol.mockResponse {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        if let data = MockURLProtocol.mockData {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
     }
-    
-    override func resume() {
-        // Simulate a network request completion
-        completion()
-    }
+
+    override func stopLoading() {}
 }
 
-class MockURLSession: URLSession, @unchecked Sendable {
-    var data: Data?
-    var response: URLResponse?
-    var error: Error?
-    
-    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        return MockURLSessionDataTask {
-            var networkingError: NetworkingError?
-            completionHandler(self.data, self.response, networkingError)
-        }
-    }
+func makeMockURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
 }
 
 class MockURLAsyncSession: URLSessionProtocol {
@@ -137,74 +142,71 @@ final class FrameNetworkingTests: XCTestCase {
 
     // Test Completion Handler Method
     func testPerformDataTaskCompletion() {
-        let mockSession = MockURLSession()
-        mockSession.data = "{ \"message\": \"Success\" }".data(using: .utf8)
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://api.framepayments.com/v1/customers")!,
-                                               statusCode: 200,
-                                               httpVersion: nil,
-                                               headerFields: nil)
-        mockSession.error = nil
-        
+        MockURLProtocol.mockData = "{ \"message\": \"Success\" }".data(using: .utf8)
+        MockURLProtocol.mockResponse = HTTPURLResponse(url: URL(string: "https://api.framepayments.com/v1/customers")!,
+                                                       statusCode: 200,
+                                                       httpVersion: nil,
+                                                       headerFields: nil)
+        MockURLProtocol.mockError = nil
+
         let networking = FrameNetworking.shared
-        networking.urlSession = mockSession
+        networking.urlSession = makeMockURLSession()
         let endpoint = MockFrameEndpoints(endpointURL: "/v1/customers", httpMethod: .GET, queryItems: nil)
-        
+
         let expectation = self.expectation(description: "Completion handler called")
-        
+
         networking.performDataTask(endpoint: endpoint) { data, response, error in
             XCTAssertNotNil(data)
             XCTAssertNotNil(response)
             XCTAssertNil(error)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testPerformDataTaskCompletionWithNoData() {
-        let mockSession = MockURLSession()
-        mockSession.data = nil
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://api.framepayments.com")!,
-                                               statusCode: 200,
-                                               httpVersion: nil,
-                                               headerFields: nil)
-        mockSession.error = nil
-        
+        MockURLProtocol.mockData = nil
+        MockURLProtocol.mockResponse = HTTPURLResponse(url: URL(string: "https://api.framepayments.com")!,
+                                                       statusCode: 200,
+                                                       httpVersion: nil,
+                                                       headerFields: nil)
+        MockURLProtocol.mockError = nil
+
         let networking = FrameNetworking.shared
-        networking.urlSession = mockSession
+        networking.urlSession = makeMockURLSession()
         let endpoint = MockFrameEndpoints(endpointURL: "/v1/customers", httpMethod: .GET, queryItems: nil)
-        
+
         let expectation = self.expectation(description: "Completion handler called")
-        
+
         networking.performDataTask(endpoint: endpoint) { data, response, error in
-            XCTAssertNil(data)
+            XCTAssertTrue(data?.isEmpty ?? true)
             XCTAssertNotNil(response)
-            XCTAssertEqual(error, .noData)
+            XCTAssertNil(error)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testPerformDataTaskCompletionWithNoResponse() {
-        let mockSession = MockURLSession()
-        mockSession.data = nil
-        mockSession.response = nil
-        mockSession.error = nil
-        
+        MockURLProtocol.mockData = nil
+        MockURLProtocol.mockResponse = nil
+        MockURLProtocol.mockError = nil
+
         let networking = FrameNetworking.shared
-        networking.urlSession = mockSession
+        networking.urlSession = makeMockURLSession()
         let endpoint = MockFrameEndpoints(endpointURL: "/v1/customers", httpMethod: .GET, queryItems: nil)
-        
+
         let expectation = self.expectation(description: "Completion handler called")
-        
+
         networking.performDataTask(endpoint: endpoint) { data, response, error in
-            XCTAssertNil(data)
+            XCTAssertTrue(data?.isEmpty ?? true)
             XCTAssertNil(response)
-            XCTAssertEqual(error, .noData)
+            XCTAssertNil(error)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/Tests/Frame-iOSTests/ProductPhaseAPITests.swift
+++ b/Tests/Frame-iOSTests/ProductPhaseAPITests.swift
@@ -110,7 +110,7 @@ final class ProductPhasesAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(mockPhase)
-            let (thirdUpdatedSubscriptionPhase, error) = try await ProductPhasesAPI.getProductPhase(productId: "prod_123", phaseId: "phase_123")
+            let (thirdUpdatedSubscriptionPhase, _) = try await ProductPhasesAPI.getProductPhase(productId: "prod_123", phaseId: "phase_123")
             XCTAssertNotNil(thirdUpdatedSubscriptionPhase)
             XCTAssertEqual(thirdUpdatedSubscriptionPhase?.pricingType, mockPhase.pricingType)
             XCTAssertEqual(thirdUpdatedSubscriptionPhase?.amount, mockPhase.amount)

--- a/Tests/Frame-iOSTests/SubscriptionsAPITests.swift
+++ b/Tests/Frame-iOSTests/SubscriptionsAPITests.swift
@@ -25,7 +25,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(subscription)
-            let (createdSecondSubscription, error) = try await SubscriptionsAPI.createSubscription(request: request)
+            let (createdSecondSubscription, _) = try await SubscriptionsAPI.createSubscription(request: request)
             XCTAssertNotNil(createdSecondSubscription)
             XCTAssertEqual(createdSecondSubscription?.currency, subscription.currency)
         } catch {
@@ -47,7 +47,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(subscription)
-            let (thirdUpdatedSubscription, error) = try await SubscriptionsAPI.updateSubscription(subscriptionId: "1234", request: request)
+            let (thirdUpdatedSubscription, _) = try await SubscriptionsAPI.updateSubscription(subscriptionId: "1234", request: request)
             XCTAssertNotNil(thirdUpdatedSubscription)
             XCTAssertEqual(thirdUpdatedSubscription?.currency, subscription.currency)
         } catch {
@@ -67,7 +67,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(SubscriptionResponses.ListSubscriptionsResponse(meta: nil, data: [firstSubscription, secondSubscription]))
-            let (secondReceivedSubscriptions, error) = try await SubscriptionsAPI.getSubscriptions()
+            let (secondReceivedSubscriptions, _) = try await SubscriptionsAPI.getSubscriptions()
             XCTAssertNotNil(secondReceivedSubscriptions)
             XCTAssertEqual(secondReceivedSubscriptions?.data?[0].currency, firstSubscription.currency)
             XCTAssertEqual(secondReceivedSubscriptions?.data?[1].currency, secondSubscription.currency)
@@ -90,7 +90,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(subscription)
-            let (thirdReceivedSubscription, error) = try await SubscriptionsAPI.getSubscription(subscriptionId: "1234")
+            let (thirdReceivedSubscription, _) = try await SubscriptionsAPI.getSubscription(subscriptionId: "1234")
             XCTAssertNotNil(thirdReceivedSubscription)
             XCTAssertEqual(thirdReceivedSubscription?.currency, subscription.currency)
         } catch {
@@ -111,7 +111,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(SubscriptionResponses.ListSubscriptionsResponse(meta: nil, data: [firstSubscription, secondSubscription]))
-            let (secondSearch, error) = try await SubscriptionsAPI.searchSubscription(request: request)
+            let (secondSearch, _) = try await SubscriptionsAPI.searchSubscription(request: request)
             XCTAssertNotNil(secondSearch)
             XCTAssertEqual(secondSearch?[0].currency, firstSubscription.currency)
             XCTAssertEqual(secondSearch?[1].currency, secondSubscription.currency)
@@ -133,7 +133,7 @@ final class SubscriptionsAPITests: XCTestCase {
         
         do {
             session.data = try JSONEncoder().encode(subscription)
-            let (thirdCancelledSubscription, error) = try await SubscriptionsAPI.getSubscription(subscriptionId: "1234")
+            let (thirdCancelledSubscription, _) = try await SubscriptionsAPI.getSubscription(subscriptionId: "1234")
             XCTAssertNotNil(thirdCancelledSubscription)
             XCTAssertEqual(thirdCancelledSubscription?.currency, subscription.currency)
         } catch {


### PR DESCRIPTION
### **Apple Pay Integration**
Adds end-to-end Apple Pay support to the Frame iOS SDK.

**_What's included:_**

**ApplePayAPI** — Decodes PKPayment tokens and creates a Frame PaymentMethod via the existing payment method endpoint, supporting both customer and account ownership.

**ApplePayRequests** — Encodable request models mapping Apple Pay token data (payment data, billing contact, payment method metadata) to the Frame API's expected wallet payload structure.

**FrameApplePayViewModel** — Orchestrates the full payment flow: presents the PKPaymentAuthorizationController, creates a payment method from the authorized token, then creates and confirms a ChargeIntent in a single callback.

**FrameApplePayButton** — A SwiftUI view wrapping PKPaymentButton that only renders when Apple Pay is available on the device. Configurable button type/style, currency, amount, and owner (customer or account).

**PKPaymentButtonWrapper** — UIKit bridge to properly render PKPaymentButton in SwiftUI.
Updated FrameCheckoutView/FrameCheckoutViewModel to surface the Apple Pay button in the checkout flow.

README documentation for the new Apple Pay integration.