### PR TITLE
Apple Pay: Fix issues with stale Device Attestation key

### DIFF
--- a/Sources/Frame/Networking/CommonObjects.swift
+++ b/Sources/Frame/Networking/CommonObjects.swift
@@ -84,6 +84,16 @@ public enum NetworkingError: Error, Equatable {
 }
 
 extension NetworkingError {
+    /// True when the server rejected a device assertion (422 with an assertion-related message).
+    /// Signals that the stored attestation key is stale and should be reset before retrying.
+    public var isAssertionRejection: Bool {
+        guard case .serverError(let statusCode, let description) = self, statusCode == 422 else {
+            return false
+        }
+        let message = (NetworkingError.extractEnvelopeMessage(description) ?? description).lowercased()
+        return message.contains("assertion") || message.contains("device not attested") || message.contains("attestation")
+    }
+
     /// True for connectivity-class failures the user can retry. False for server-validation
     /// errors that should stay in the form so the user can correct the input.
     public var isTransport: Bool {
@@ -113,7 +123,7 @@ extension NetworkingError {
     /// handled; `error_details` is preferred over the generic `error` key (which tends to be the
     /// HTTP status name like `"Unprocessable Entity"`). Returns nil when the body isn't valid
     /// JSON or no usable field is present.
-    private static func extractEnvelopeMessage(_ raw: String) -> String? {
+    static func extractEnvelopeMessage(_ raw: String) -> String? {
         guard !raw.isEmpty,
               let data = raw.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
+++ b/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
@@ -47,7 +47,7 @@ public class DeviceAttestationManager: ObservableObject {
     }
 
     private init() {
-        isDeviceAttested = readKeychainItem(keychainKey) != nil
+        isDeviceAttested = readKeyIdFromKeychain() != nil
     }
 
     /// Performs the full device attestation flow:

--- a/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
@@ -139,6 +139,9 @@ extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
                 )
             }
             guard let paymentMethod else {
+                if methodError?.isAssertionRejection == true {
+                    DeviceAttestationManager.shared.resetAttestation()
+                }
                 completion?(.failure(methodError ?? NetworkingError.unknownError))
                 return PKPaymentAuthorizationResult(status: .failure, errors: nil)
             }

--- a/Sources/Frame/Views/FrameCheckoutView.swift
+++ b/Sources/Frame/Views/FrameCheckoutView.swift
@@ -138,8 +138,14 @@ public struct FrameCheckoutView: View {
                 // missing-config case the host can correct without restarting checkout.
                 // Prefer the server's `error_details.message` for server errors; fall back to a
                 // generic message for transport errors and any other Error subtype.
-                let message = (error as? NetworkingError)?.toastMessage()
-                    ?? "Error: Apple Pay could not complete. Please try again or use a card."
+                let message: String
+                if let networkingError = error as? NetworkingError {
+                    message = networkingError.toastMessage()
+                } else if error is DeviceAttestationError {
+                    message = "Error: Apple Pay is not available, there was a device attestation error. Please use a card instead."
+                } else {
+                    message = "Error: Apple Pay could not complete. Please try again or use a card."
+                }
                 FrameToastCenter.shared.show(message)
             }
         }

--- a/Tests/Frame-iOSTests/FrameNetworkingTests.swift
+++ b/Tests/Frame-iOSTests/FrameNetworkingTests.swift
@@ -210,3 +210,44 @@ final class FrameNetworkingTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 }
+
+// MARK: - NetworkingError.isAssertionRejection tests
+
+final class NetworkingErrorAssertionRejectionTests: XCTestCase {
+
+    private func make422(_ body: String) -> NetworkingError {
+        .serverError(statusCode: 422, errorDescription: body)
+    }
+
+    func testAssertionSignatureFailure() {
+        let error = make422(#"{"status":422,"error":"Unprocessable Entity","code":"validation_errors","error_details":"Assertion signature verification failed"}"#)
+        XCTAssertTrue(error.isAssertionRejection)
+    }
+
+    func testDeviceNotAttested() {
+        let error = make422(#"{"status":422,"error":"Unprocessable Entity","code":"validation_errors","error_details":"Device not attested"}"#)
+        XCTAssertTrue(error.isAssertionRejection)
+    }
+
+    func testInvalidAssertionObject() {
+        let error = make422(#"{"status":422,"error":"Unprocessable Entity","code":"validation_errors","error_details":"Invalid assertion object"}"#)
+        XCTAssertTrue(error.isAssertionRejection)
+    }
+
+    func testUnrelatedValidationError() {
+        let error = make422(#"{"status":422,"error":"Unprocessable Entity","code":"validation_errors","error_details":"Card submitted is not a test card"}"#)
+        XCTAssertFalse(error.isAssertionRejection)
+    }
+
+    func testNon422ServerError() {
+        let error = NetworkingError.serverError(statusCode: 500, errorDescription: #"{"error_details":"Assertion signature verification failed"}"#)
+        XCTAssertFalse(error.isAssertionRejection)
+    }
+
+    func testNonServerErrors() {
+        XCTAssertFalse(NetworkingError.unknownError.isAssertionRejection)
+        XCTAssertFalse(NetworkingError.noData.isAssertionRejection)
+        XCTAssertFalse(NetworkingError.decodingFailed.isAssertionRejection)
+        XCTAssertFalse(NetworkingError.invalidURL.isAssertionRejection)
+    }
+}


### PR DESCRIPTION
Device attestation did not automatically reset when an error arose from the backend about stale attestation keys.