### PR TITLE
API: Support Publishable Key Rewrite (FRA-4313)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -52,8 +52,23 @@ jobs:
           fi
           echo "✅ Dark-mode lint passed."
 
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          # Pick the highest installed Xcode 16.x (image rotation changes the exact
+          # patch version, so don't hardcode a path that may not exist).
+          XCODE_APP="$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || true)"
+          if [ -z "$XCODE_APP" ]; then
+            # Fall back to any installed Xcode, then the system default.
+            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1 || true)"
+          fi
+          if [ -n "$XCODE_APP" ]; then
+            echo "Selecting $XCODE_APP"
+            sudo xcode-select -s "$XCODE_APP"
+          else
+            echo "No /Applications/Xcode*.app found; using current selection."
+          fi
+          xcodebuild -version
 
       - name: Configure Prove Swift Package Registry
         run: |

--- a/FrameExample-iOS/FrameExample-iOS/ContentView.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentView.swift
@@ -92,8 +92,10 @@ struct ContentView: View {
             Text(applePayResult ?? "")
         }
         .sheet(isPresented: $showOnboardingSheet, content: {
-//            OnboardingContainerView(accountId: "ENTER_TEST_ACCOUNT_ID", requiredCapabilities: [], applePayMerchantId: "ENTER_MERCHANT_PAY_ID")
-            OnboardingContainerView(requiredCapabilities: [.kycPrefill, .cardSend, .geoCompliance, .bankAccountReceive, .ageVerification])
+            // clientSecret is the onb_sess_… token minted above; the SDK binds every onboarding
+            // request to it, scoping the flow to a single account.
+            OnboardingContainerView(clientSecret: viewModel.onboardingClientSecret,
+                                    requiredCapabilities: [.kycPrefill, .cardSend, .geoCompliance, .bankAccountReceive, .ageVerification])
         })
         .sheet(isPresented: $showCheckoutView) {
             FrameCartView(accountId: accountId,
@@ -279,7 +281,13 @@ struct ContentView: View {
     
     var onboardingButton: some View {
         Button {
-            self.showOnboardingSheet = true
+            // Demo/testing only: mint an onboarding-session token from the configured sk_ before
+            // presenting the flow, then launch. Production apps mint this token on their backend
+            // (POST /v1/onboarding_sessions) and pass it in as the clientSecret — see ContentViewModel.
+            Task {
+                await viewModel.mintOnboardingClientSecret(accountId: accountId)
+                self.showOnboardingSheet = true
+            }
         } label: {
             Text("Show Onboarding Flow")
                 .font(.headline)

--- a/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
@@ -22,16 +22,19 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
     let applePayMerchantId: String = "merchant.com.yourapp"
     
     init() {
-        // Note: To use this SDK, you must add your sandbox publishable and secret keys here.
-        FrameNetworking.shared.initializeWithAPIKey("ENTER_SECRET_KEY_HERE",
-                                                    publishableKey: "ENTER_PUBLISHABLE_KEY_HERE",
-//                                                    theme: FrameTheme(
-//                                                        colors: .init(primaryButton: .purple, error: .orange),
-//                                                        fonts: .init(title: .custom("Avenir-Black", size: 28)),
-//                                                        radii: .init(medium: 16)
-//                                                    ),
-                                                    applePayMerchantId: applePayMerchantId,
-                                                    debugMode: true)
+        // The SDK is publishable-key first: pass your publishable key (pk_) here. Secret keys
+        // grant full merchant privileges and must not ship in an app binary — serve sk_ from your
+        // backend. This example sets a secret key only to exercise the legacy server-side demo
+        // calls below; production apps should omit it.
+        FrameNetworking.shared.initialize(publishableKey: "ENTER_PUBLISHABLE_KEY_HERE",
+                                          secretKey: "ENTER_SECRET_KEY_HERE",
+//                                          theme: FrameTheme(
+//                                              colors: .init(primaryButton: .purple, error: .orange),
+//                                              fonts: .init(title: .custom("Avenir-Black", size: 28)),
+//                                              radii: .init(medium: 16)
+//                                          ),
+                                          applePayMerchantId: applePayMerchantId,
+                                          debugMode: true)
 
         Task {
             await self.getCustomers()

--- a/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
@@ -17,6 +17,8 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
     @Published var customers: [FrameObjects.Customer] = []
     @Published var chargeIntents: [FrameObjects.ChargeIntent] = []
     @Published var refunds: [FrameObjects.Refund] = []
+    /// The onboarding-session token (`onb_sess_…`) minted for the demo flow, if any.
+    @Published var onboardingClientSecret: String?
     
     // Replace with your Apple Pay merchant ID registered in your entitlements
     let applePayMerchantId: String = "merchant.com.yourapp"
@@ -207,6 +209,36 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
             }
         } catch let error {
             print (error.localizedDescription)
+        }
+    }
+
+    // MARK: Onboarding session (demo / testing only)
+
+    /// Mints an onboarding-session token (`onb_sess_…`) for the given account so the example app can
+    /// exercise the onboarding flow end-to-end.
+    ///
+    /// - Important: This is **not** the intended production path. Creating an onboarding session is a
+    ///   server-only operation that authenticates with your secret key (`sk_`), which must never ship
+    ///   in an app binary. Real integrations mint this token from their backend
+    ///   (`POST /v1/onboarding_sessions`) and hand it to the app. The example app does it inline only
+    ///   because it already configures an `sk_` to exercise the legacy server-side demo calls.
+    /// - Parameter accountId: The existing Frame account to onboard.
+    func mintOnboardingClientSecret(accountId: String) async {
+        let request = OnboardingSessionRequest.CreateOnboardingSessionRequest(
+            accountId: accountId,
+            steps: [.idVerification, .geoCompliance, .paymentMethod]
+        )
+        do {
+            let (session, error) = try await OnboardingSessionsAPI.createOnboardingSession(request: request)
+            if let clientSecret = session?.clientSecret {
+                DispatchQueue.main.async {
+                    self.onboardingClientSecret = clientSecret
+                }
+            } else {
+                print("⚠️ Frame example: failed to mint onboarding session token. Error: \(String(describing: error))")
+            }
+        } catch let error {
+            print(error.localizedDescription)
         }
     }
 }

--- a/Sources/Frame/Networking/Accounts/AccountsAPI.swift
+++ b/Sources/Frame/Networking/Accounts/AccountsAPI.swift
@@ -109,8 +109,8 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
 
     /// Retrieves a single account by its ID.
     ///
-    /// - Note: Standalone account retrieval is a server operation and authenticates with the secret
-    ///   key. During the SDK onboarding flow these calls instead carry the active onboarding-session
+    /// - Note: This is a client-safe read and authenticates with the publishable key (`pk_`).
+    ///   During the SDK onboarding flow these calls instead carry the active onboarding-session
     ///   token automatically — see ``FrameNetworking/beginOnboardingSession(clientSecret:)``.
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to retrieve.
@@ -120,7 +120,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
        guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
@@ -164,14 +164,15 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     }
 
     /// Retrieves all payment methods associated with the specified account.
+    ///
+    /// - Note: This is a client-safe read and authenticates with the publishable key (`pk_`).
     /// - Parameter accountId: The unique identifier of the account whose payment methods to retrieve.
     /// - Returns: A tuple containing a ``PaymentMethodResponses/ListPaymentMethodsResponse`` and any ``NetworkingError``.
-    @available(*, deprecated, message: "Server-only: list account payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsForAccount(accountId: String) async throws -> (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -294,7 +295,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     public static func getAccountWith(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -340,15 +341,16 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     }
 
     /// Completion-handler variant of `getPaymentMethodsForAccount(accountId:)`.
+    ///
+    /// - Note: This is a client-safe read and authenticates with the publishable key (`pk_`).
     /// - Parameters:
     ///   - accountId: The unique identifier of the account whose payment methods to retrieve.
     ///   - completionHandler: Called with a ``PaymentMethodResponses/ListPaymentMethodsResponse`` and any ``NetworkingError``.
-    @available(*, deprecated, message: "Server-only: list account payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsForAccount(accountId: String, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Accounts/AccountsAPI.swift
+++ b/Sources/Frame/Networking/Accounts/AccountsAPI.swift
@@ -52,7 +52,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.createAccount
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
@@ -77,7 +77,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.updateAccount(accountId: accountId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -99,7 +99,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
                                                     externalId: externalId,
                                                     includeDisabled: includeDisabled)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -120,7 +120,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
        guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
@@ -139,7 +139,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
        guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.deleteAccountWith(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -155,7 +155,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !email.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.searchAccounts(email: email)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -171,7 +171,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -187,7 +187,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.restrictAccount(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -203,7 +203,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.unrestrictAccount(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -236,7 +236,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.createAccount
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -255,7 +255,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.updateAccount(accountId: accountId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -278,7 +278,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
                                                     externalId: externalId,
                                                     includeDisabled: includeDisabled)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -294,7 +294,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     public static func getAccountWith(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -312,7 +312,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     public static func deleteAccountWith(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.deleteAccountWith(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -330,7 +330,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !email.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.searchAccounts(email: email)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -348,7 +348,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -366,7 +366,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.restrictAccount(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -384,7 +384,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.unrestrictAccount(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Accounts/AccountsAPI.swift
+++ b/Sources/Frame/Networking/Accounts/AccountsAPI.swift
@@ -40,6 +40,10 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     //MARK: Methods using async/await
 
     /// Creates a new account using the provided request body.
+    ///
+    /// - Note: Standalone account creation is a server operation and authenticates with the secret
+    ///   key. During the SDK onboarding flow these calls instead carry the active onboarding-session
+    ///   token (`onb_sess_…`) automatically — see ``FrameNetworking/beginOnboardingSession(clientSecret:)``.
     /// - Parameters:
     ///   - request: The details required to create the account.
     ///   - forTesting: When `true`, skips Sift login-event collection; defaults to `false`.
@@ -48,7 +52,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.createAccount
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
@@ -60,6 +64,10 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     }
 
     /// Updates an existing account identified by its ID.
+    ///
+    /// - Note: Standalone account updates are a server operation and authenticate with the secret
+    ///   key. During the SDK onboarding flow these calls instead carry the active onboarding-session
+    ///   token automatically — see ``FrameNetworking/beginOnboardingSession(clientSecret:)``.
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to update.
     ///   - request: The fields to update on the account.
@@ -69,7 +77,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.updateAccount(accountId: accountId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -84,13 +92,14 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     ///   - externalId: Optional external identifier to filter by.
     ///   - includeDisabled: When `true`, includes disabled accounts in the results; defaults to `false`.
     /// - Returns: A tuple containing an ``AccountResponses/ListAccountsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: enumerate accounts from your backend with sk_, not from the app.")
     public static func getAccounts(status: FrameObjects.AccountStatus?, type: FrameObjects.AccountType?, externalId: String?, includeDisabled: Bool = false) async throws -> (AccountResponses.ListAccountsResponse?, NetworkingError?) {
         let endpoint = AccountEndpoints.getAccounts(status: status,
                                                     type: type,
                                                     externalId: externalId,
                                                     includeDisabled: includeDisabled)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -99,6 +108,10 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     }
 
     /// Retrieves a single account by its ID.
+    ///
+    /// - Note: Standalone account retrieval is a server operation and authenticates with the secret
+    ///   key. During the SDK onboarding flow these calls instead carry the active onboarding-session
+    ///   token automatically — see ``FrameNetworking/beginOnboardingSession(clientSecret:)``.
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to retrieve.
     ///   - forTesting: When `true`, skips Sift login-event collection; defaults to `false`.
@@ -107,7 +120,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
        guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
@@ -121,11 +134,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// Deletes the account identified by the given ID.
     /// - Parameter accountId: The unique identifier of the account to delete.
     /// - Returns: A tuple containing the deleted ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: delete accounts from your backend with sk_, not from the app.")
     public static func deleteAccountWith(accountId: String) async throws -> (FrameObjects.Account?, NetworkingError?) {
        guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.deleteAccountWith(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -136,11 +150,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// Searches for accounts matching the given email address.
     /// - Parameter email: The email address to search by.
     /// - Returns: A tuple containing an ``AccountResponses/ListAccountsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: search accounts from your backend with sk_, not from the app.")
     public static func searchAccounts(email: String) async throws -> (AccountResponses.ListAccountsResponse?, NetworkingError?) {
         guard !email.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.searchAccounts(email: email)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -151,11 +166,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// Retrieves all payment methods associated with the specified account.
     /// - Parameter accountId: The unique identifier of the account whose payment methods to retrieve.
     /// - Returns: A tuple containing a ``PaymentMethodResponses/ListPaymentMethodsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list account payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsForAccount(accountId: String) async throws -> (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -166,11 +182,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// Restricts the account identified by the given ID, preventing further activity.
     /// - Parameter accountId: The unique identifier of the account to restrict.
     /// - Returns: A tuple containing the updated ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: restrict accounts from your backend with sk_, not from the app.")
     public static func restrictAccount(accountId: String) async throws -> (FrameObjects.Account?, NetworkingError?) {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.restrictAccount(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -181,11 +198,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// Removes the restriction on the account identified by the given ID, restoring normal activity.
     /// - Parameter accountId: The unique identifier of the account to unrestrict.
     /// - Returns: A tuple containing the updated ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: unrestrict accounts from your backend with sk_, not from the app.")
     public static func unrestrictAccount(accountId: String) async throws -> (FrameObjects.Account?, NetworkingError?) {
         guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = AccountEndpoints.unrestrictAccount(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -218,7 +236,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.createAccount
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -237,7 +255,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
         let endpoint = AccountEndpoints.updateAccount(accountId: accountId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -253,13 +271,14 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     ///   - externalId: Optional external identifier to filter by.
     ///   - includeDisabled: When `true`, includes disabled accounts in the results; defaults to `false`.
     ///   - completionHandler: Called with an ``AccountResponses/ListAccountsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: enumerate accounts from your backend with sk_, not from the app.")
     public static func getAccounts(status: FrameObjects.AccountStatus?, type: FrameObjects.AccountType?, externalId: String?, includeDisabled: Bool = false, completionHandler: @escaping @Sendable (AccountResponses.ListAccountsResponse?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.getAccounts(status: status,
                                                     type: type,
                                                     externalId: externalId,
                                                     includeDisabled: includeDisabled)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -275,7 +294,7 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     public static func getAccountWith(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.getAccountWith(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.profile?.individual?.email ?? decodedResponse.profile?.business?.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -289,10 +308,11 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to delete.
     ///   - completionHandler: Called with the deleted ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: delete accounts from your backend with sk_, not from the app.")
     public static func deleteAccountWith(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         let endpoint = AccountEndpoints.deleteAccountWith(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -305,11 +325,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - email: The email address to search by.
     ///   - completionHandler: Called with an ``AccountResponses/ListAccountsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: search accounts from your backend with sk_, not from the app.")
     public static func searchAccounts(email: String, completionHandler: @escaping @Sendable (AccountResponses.ListAccountsResponse?, NetworkingError?) -> Void) {
         guard !email.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.searchAccounts(email: email)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(AccountResponses.ListAccountsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -322,11 +343,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - accountId: The unique identifier of the account whose payment methods to retrieve.
     ///   - completionHandler: Called with a ``PaymentMethodResponses/ListPaymentMethodsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list account payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsForAccount(accountId: String, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.getAccountPaymentMethods(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -339,11 +361,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to restrict.
     ///   - completionHandler: Called with the updated ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: restrict accounts from your backend with sk_, not from the app.")
     public static func restrictAccount(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.restrictAccount(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -356,11 +379,12 @@ public class AccountsAPI: AccountsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - accountId: The unique identifier of the account to unrestrict.
     ///   - completionHandler: Called with the updated ``FrameObjects/Account`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: unrestrict accounts from your backend with sk_, not from the app.")
     public static func unrestrictAccount(accountId: String, completionHandler: @escaping @Sendable (FrameObjects.Account?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = AccountEndpoints.unrestrictAccount(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Account.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Capabilities/CapabilitiesAPI.swift
+++ b/Sources/Frame/Networking/Capabilities/CapabilitiesAPI.swift
@@ -89,7 +89,7 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
         guard !accountId.isEmpty, !name.isEmpty else { return (nil, nil) }
         let endpoint = CapabilityEndpoints.getCapabilityWith(accountId: accountId, name: name)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -108,7 +108,7 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
         guard !accountId.isEmpty, !name.isEmpty else { return (nil, nil) }
         let endpoint = CapabilityEndpoints.disableCapabilityWith(accountId: accountId, name: name)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -167,7 +167,7 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
         guard !accountId.isEmpty, !name.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = CapabilityEndpoints.getCapabilityWith(accountId: accountId, name: name)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -187,7 +187,7 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
         guard !accountId.isEmpty, !name.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = CapabilityEndpoints.disableCapabilityWith(accountId: accountId, name: name)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Capabilities/CapabilitiesAPI.swift
+++ b/Sources/Frame/Networking/Capabilities/CapabilitiesAPI.swift
@@ -84,11 +84,12 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
     ///   - accountId: The unique identifier of the account.
     ///   - name: The name of the capability to retrieve.
     /// - Returns: A tuple containing the matching capability and any networking error encountered.
+    @available(*, deprecated, message: "Server-only: manage individual capabilities from your backend with sk_, not from the app.")
     public static func getCapabilityWith(accountId: String, name: String) async throws -> (FrameObjects.Capability?, NetworkingError?) {
         guard !accountId.isEmpty, !name.isEmpty else { return (nil, nil) }
         let endpoint = CapabilityEndpoints.getCapabilityWith(accountId: accountId, name: name)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -102,11 +103,12 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
     ///   - accountId: The unique identifier of the account.
     ///   - name: The name of the capability to disable.
     /// - Returns: A tuple containing the updated capability and any networking error encountered.
+    @available(*, deprecated, message: "Server-only: manage individual capabilities from your backend with sk_, not from the app.")
     public static func disableCapabilityWith(accountId: String, name: String) async throws -> (FrameObjects.Capability?, NetworkingError?) {
         guard !accountId.isEmpty, !name.isEmpty else { return (nil, nil) }
         let endpoint = CapabilityEndpoints.disableCapabilityWith(accountId: accountId, name: name)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -160,11 +162,12 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
     ///   - accountId: The unique identifier of the account.
     ///   - name: The name of the capability to retrieve.
     ///   - completionHandler: Called with the matching capability and any networking error encountered.
+    @available(*, deprecated, message: "Server-only: manage individual capabilities from your backend with sk_, not from the app.")
     public static func getCapabilityWith(accountId: String, name: String, completionHandler: @escaping @Sendable (FrameObjects.Capability?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty, !name.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = CapabilityEndpoints.getCapabilityWith(accountId: accountId, name: name)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -179,11 +182,12 @@ public class CapabilitiesAPI: CapabilitiesProtocol, @unchecked Sendable {
     ///   - accountId: The unique identifier of the account.
     ///   - name: The name of the capability to disable.
     ///   - completionHandler: Called with the updated capability and any networking error encountered.
+    @available(*, deprecated, message: "Server-only: manage individual capabilities from your backend with sk_, not from the app.")
     public static func disableCapabilityWith(accountId: String, name: String, completionHandler: @escaping @Sendable (FrameObjects.Capability?, NetworkingError?) -> Void) {
         guard !accountId.isEmpty, !name.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = CapabilityEndpoints.disableCapabilityWith(accountId: accountId, name: name)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Capability.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
+++ b/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
@@ -12,21 +12,21 @@ protocol ChargeIntentsProtocol {
     //async/await
     static func createChargeIntent(request: ChargeIntentsRequests.CreateChargeIntentRequest) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
     static func captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
-    static func confirmChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
+    static func confirmChargeIntent(intentId: String, clientSecret: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
     static func cancelChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
     static func voidRemainingChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
     static func getAllChargeIntents(page: Int?, perPage: Int?) async throws -> (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?)
-    static func getChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
+    static func getChargeIntent(intentId: String, clientSecret: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
     static func updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?)
 
     // completionHandlers
     static func createChargeIntent(request: ChargeIntentsRequests.CreateChargeIntentRequest, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
     static func captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
-    static func confirmChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
+    static func confirmChargeIntent(intentId: String, clientSecret: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
     static func cancelChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
     static func voidRemainingChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
     static func getAllChargeIntents(page: Int?, perPage: Int?, completionHandler: @escaping @Sendable (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) -> Void)
-    static func getChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
+    static func getChargeIntent(intentId: String, clientSecret: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
     static func updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void)
 }
 
@@ -37,6 +37,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     // MARK: - async/await
 
     /// Creates a new charge intent, automatically attaching the current Sonar session ID and client IP fraud signals.
+    ///
+    /// - Important: Creating a charge intent is a **server-only** operation — your server owns the
+    ///   amount and must mint it with your secret key (`sk_`). Under the publishable-key model the
+    ///   client retrieves/confirms a server-minted intent via its `client_secret`
+    ///   (see ``confirmChargeIntent(intentId:clientSecret:)``). This method authenticates with the
+    ///   secret key and is retained only for existing in-app charge flows.
     ///
     /// - Parameter request: The parameters for the charge intent to create.
     /// - Returns: A tuple containing the created ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
@@ -50,7 +56,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -64,12 +70,13 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - intentId: The unique identifier of the charge intent to capture.
     ///   - request: Additional capture parameters such as amount to capture.
     /// - Returns: A tuple containing the updated ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only: capture charge intents from your backend with sk_, not from the app.")
     public static func captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
         guard !intentId.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.captureChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -77,15 +84,22 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         }
     }
 
-    /// Confirms a charge intent, moving it to an authorised state.
+    /// Confirms a server-minted charge intent in-app, moving it to an authorised state.
     ///
-    /// - Parameter intentId: The unique identifier of the charge intent to confirm.
+    /// The intent must already exist — your server creates it (`POST /v1/charge_intents` with
+    /// `sk_`) and hands the resulting `client_secret` to your app. Confirmation authenticates
+    /// with that `client_secret`, never the secret key. Mirrors `frame-js`'s
+    /// `confirmCardPayment(clientSecret)`.
+    ///
+    /// - Parameters:
+    ///   - intentId: The unique identifier of the charge intent to confirm.
+    ///   - clientSecret: The charge intent's server-minted `client_secret` (`ci_<id>_secret_…`).
     /// - Returns: A tuple containing the confirmed ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
-    public static func confirmChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
-        guard !intentId.isEmpty else { return (nil, nil) }
+    public static func confirmChargeIntent(intentId: String, clientSecret: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
+        guard !intentId.isEmpty, !clientSecret.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.confirmChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .clientSecret(clientSecret))
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
 //            SiftManager.addNewSiftEvent(transactionType: .authorize, eventId: decodedResponse.id)
             return (decodedResponse, error)
@@ -98,11 +112,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///
     /// - Parameter intentId: The unique identifier of the charge intent to cancel.
     /// - Returns: A tuple containing the cancelled ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only: cancel charge intents from your backend with sk_, not from the app.")
     public static func cancelChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
         guard !intentId.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.cancelChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -116,10 +131,11 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve, or `nil` for the first page.
     ///   - perPage: The number of results per page, or `nil` to use the API default.
     /// - Returns: A tuple containing a ``ChargeIntentResponses/ListChargeIntentsResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only: enumerate charge intents from your backend with sk_, not from the app.")
     public static func getAllChargeIntents(page: Int? = nil, perPage: Int? = nil) async throws -> (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) {
         let endpoint = ChargeIntentEndpoints.getAllChargeIntents(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ChargeIntentResponses.ListChargeIntentsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -127,15 +143,17 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         }
     }
 
-    /// Fetches a single charge intent by its identifier.
+    /// Retrieves a single server-minted charge intent in-app using its `client_secret`.
     ///
-    /// - Parameter intentId: The unique identifier of the charge intent to retrieve.
+    /// - Parameters:
+    ///   - intentId: The unique identifier of the charge intent to retrieve.
+    ///   - clientSecret: The charge intent's server-minted `client_secret` (`ci_<id>_secret_…`).
     /// - Returns: A tuple containing the matching ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
-    public static func getChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
-        guard !intentId.isEmpty else { return (nil, nil) }
+    public static func getChargeIntent(intentId: String, clientSecret: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
+        guard !intentId.isEmpty, !clientSecret.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.getChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .clientSecret(clientSecret))
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -149,11 +167,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - intentId: The unique identifier of the charge intent to update.
     ///   - request: The fields to update on the charge intent.
     /// - Returns: A tuple containing the updated ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only: update charge intents from your backend with sk_, not from the app.")
     public static func updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
         let endpoint = ChargeIntentEndpoints.updateChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -165,11 +184,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///
     /// - Parameter intentId: The unique identifier of the charge intent whose remaining authorisation should be voided.
     /// - Returns: A tuple containing the updated ``FrameObjects/ChargeIntent`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only: void charge intents from your backend with sk_, not from the app.")
     public static func voidRemainingChargeIntent(intentId: String) async throws -> (FrameObjects.ChargeIntent?, NetworkingError?) {
         guard !intentId.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.voidRemainingChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -193,7 +213,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -208,11 +228,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - intentId: The unique identifier of the charge intent to capture.
     ///   - request: Additional capture parameters such as amount to capture.
     ///   - completionHandler: Called with the updated ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: capture charge intents from your backend with sk_, not from the app.")
     public static func captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.captureChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -221,15 +242,17 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         }
     }
 
-    /// Completion-handler variant of ``confirmChargeIntentAsync(_:)``.
+    /// Completion-handler variant of ``confirmChargeIntent(intentId:clientSecret:)``.
     ///
     /// - Parameters:
     ///   - intentId: The unique identifier of the charge intent to confirm.
+    ///   - clientSecret: The charge intent's server-minted `client_secret` (`ci_<id>_secret_…`).
     ///   - completionHandler: Called with the confirmed ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
-    public static func confirmChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
+    public static func confirmChargeIntent(intentId: String, clientSecret: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
+        guard !intentId.isEmpty, !clientSecret.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = ChargeIntentEndpoints.confirmChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .clientSecret(clientSecret)) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
 //                SiftManager.addNewSiftEvent(transactionType: .authorize, eventId: decodedResponse.id)
                 completionHandler(decodedResponse, error)
@@ -244,10 +267,11 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - intentId: The unique identifier of the charge intent to cancel.
     ///   - completionHandler: Called with the cancelled ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: cancel charge intents from your backend with sk_, not from the app.")
     public static func cancelChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.cancelChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -262,10 +286,11 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve, or `nil` for the first page.
     ///   - perPage: The number of results per page, or `nil` to use the API default.
     ///   - completionHandler: Called with a ``ChargeIntentResponses/ListChargeIntentsResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: enumerate charge intents from your backend with sk_, not from the app.")
     public static func getAllChargeIntents(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.getAllChargeIntents(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ChargeIntentResponses.ListChargeIntentsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -274,15 +299,17 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         }
     }
 
-    /// Completion-handler variant of ``getChargeIntentAsync(_:)``.
+    /// Completion-handler variant of ``getChargeIntent(intentId:clientSecret:)``.
     ///
     /// - Parameters:
     ///   - intentId: The unique identifier of the charge intent to retrieve.
+    ///   - clientSecret: The charge intent's server-minted `client_secret` (`ci_<id>_secret_…`).
     ///   - completionHandler: Called with the matching ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
-    public static func getChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
+    public static func getChargeIntent(intentId: String, clientSecret: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
+        guard !intentId.isEmpty, !clientSecret.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = ChargeIntentEndpoints.getChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .clientSecret(clientSecret)) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -297,11 +324,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     ///   - intentId: The unique identifier of the charge intent to update.
     ///   - request: The fields to update on the charge intent.
     ///   - completionHandler: Called with the updated ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: update charge intents from your backend with sk_, not from the app.")
     public static func updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.updateChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -315,11 +343,12 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - intentId: The unique identifier of the charge intent whose remaining authorisation should be voided.
     ///   - completionHandler: Called with the updated ``FrameObjects/ChargeIntent`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: void charge intents from your backend with sk_, not from the app.")
     public static func voidRemainingChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
         guard !intentId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = ChargeIntentEndpoints.voidRemainingChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
+++ b/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
@@ -56,7 +56,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -76,7 +76,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         let endpoint = ChargeIntentEndpoints.captureChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -117,7 +117,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         guard !intentId.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.cancelChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -135,7 +135,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     public static func getAllChargeIntents(page: Int? = nil, perPage: Int? = nil) async throws -> (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) {
         let endpoint = ChargeIntentEndpoints.getAllChargeIntents(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ChargeIntentResponses.ListChargeIntentsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -172,7 +172,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         let endpoint = ChargeIntentEndpoints.updateChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -189,7 +189,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         guard !intentId.isEmpty else { return (nil, nil) }
         let endpoint = ChargeIntentEndpoints.voidRemainingChargeIntent(intentId: intentId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -213,7 +213,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -233,7 +233,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         let endpoint = ChargeIntentEndpoints.captureChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -271,7 +271,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     public static func cancelChargeIntent(intentId: String, completionHandler: @escaping @Sendable (FrameObjects.ChargeIntent?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.cancelChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -290,7 +290,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
     public static func getAllChargeIntents(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) -> Void) {
         let endpoint = ChargeIntentEndpoints.getAllChargeIntents(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ChargeIntentResponses.ListChargeIntentsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -329,7 +329,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         let endpoint = ChargeIntentEndpoints.updateChargeIntent(intentId: intentId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -348,7 +348,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         guard !intentId.isEmpty else { return completionHandler(nil, nil) }
         let endpoint = ChargeIntentEndpoints.voidRemainingChargeIntent(intentId: intentId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.ChargeIntent.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/CommonObjects.swift
+++ b/Sources/Frame/Networking/CommonObjects.swift
@@ -14,6 +14,28 @@ class NetworkingConstants {
     static let mainAPIURL: String = "https://api.framepayments.com"
 }
 
+/// Selects which credential authenticates a Frame API request.
+///
+/// The Frame iOS SDK is **publishable-key first**: client-safe endpoints (tokenization,
+/// config, device attestation, charge confirm) authenticate with your publishable key
+/// (`pk_`). A publishable key is safe to embed in an app binary — it can only tokenize and
+/// retrieve/confirm objects the client already owns.
+///
+/// - Warning: ``secret`` sends your secret key (`sk_`), which grants full merchant
+///   privileges. A secret key must never ship inside an app binary; serve it only from your
+///   backend. The SDK emits a one-time runtime warning the first time ``secret`` is used.
+public enum FrameAuthMode: Sendable {
+    /// Authenticate with the publishable key (`pk_`). This is the default for all client-safe endpoints.
+    case publishable
+    /// Authenticate with the secret key (`sk_`). Server-only — avoid shipping this in an app binary.
+    case secret
+    /// Authenticate with a server-minted, per-object client secret used as a Bearer token.
+    ///
+    /// Covers both the charge-intent / 3DS `client_secret` (`ci_<id>_secret_…`) and the
+    /// onboarding-session token (`onb_sess_…`).
+    case clientSecret(String)
+}
+
 /// The HTTP method to use when making a network request.
 public enum HTTPMethod: String {
     /// Removes the specified resource.

--- a/Sources/Frame/Networking/CommonObjects.swift
+++ b/Sources/Frame/Networking/CommonObjects.swift
@@ -25,7 +25,8 @@ class NetworkingConstants {
 ///   privileges. A secret key must never ship inside an app binary; serve it only from your
 ///   backend. The SDK emits a one-time runtime warning the first time ``secret`` is used.
 public enum FrameAuthMode: Sendable {
-    /// Authenticate with the publishable key (`pk_`). This is the default for all client-safe endpoints.
+    /// Authenticate with the publishable key (`pk_`). Set explicitly on client-safe endpoints
+    /// (tokenization, config, device attestation) that are safe to call from an app binary.
     case publishable
     /// Authenticate with the secret key (`sk_`). Server-only — avoid shipping this in an app binary.
     case secret

--- a/Sources/Frame/Networking/Configuration/ConfigurationAPI.swift
+++ b/Sources/Frame/Networking/Configuration/ConfigurationAPI.swift
@@ -34,7 +34,7 @@ public class ConfigurationAPI: ConfigurationProtocol, @unchecked Sendable {
     /// - Throws: A networking error if the request fails.
     public static func getEvervaultConfiguration() async throws -> ConfigurationResponses.GetEvervaultConfigurationResponse? {
         let endpoint = ConfigurationEndpoints.getEvervaultConfiguration
-        let (data, _) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, _) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ConfigurationResponses.GetEvervaultConfigurationResponse.self, from: data) {
             // Save configuration to chain
             ConfigurationAPI.saveConfigurationToKeychain(key: ConfigurationKeys.evervault.rawValue, value: decodedResponse)
@@ -51,7 +51,7 @@ public class ConfigurationAPI: ConfigurationProtocol, @unchecked Sendable {
     /// - Throws: A networking error if the request fails.
     public static func getSiftConfiguration() async throws -> ConfigurationResponses.GetSiftConfigurationResponse? {
         let endpoint = ConfigurationEndpoints.getSiftConfiguration
-        let (data, _) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, _) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ConfigurationResponses.GetSiftConfigurationResponse.self, from: data) {
             // Save configuration to chain
             ConfigurationAPI.saveConfigurationToKeychain(key: ConfigurationKeys.sift.rawValue, value: decodedResponse)

--- a/Sources/Frame/Networking/Customers/CustomersAPI.swift
+++ b/Sources/Frame/Networking/Customers/CustomersAPI.swift
@@ -41,11 +41,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - request: The customer creation parameters.
     ///   - forTesting: Pass `true` to skip Sift login-event collection; defaults to `false`.
     /// - Returns: A tuple containing the created ``FrameObjects/Customer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createCustomer(request: CustomerRequest.CreateCustomerRequest, forTesting: Bool = false) async throws -> (FrameObjects.Customer?, NetworkingError?) {
         let endpoint = CustomerEndpoints.createCustomer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
@@ -60,11 +61,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///
     /// - Parameter customerId: The unique identifier of the customer to delete.
     /// - Returns: A tuple containing a ``CustomerResponses/DeleteCustomerResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteCustomer(customerId: String) async throws -> (CustomerResponses.DeleteCustomerResponse?, NetworkingError?) {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.deleteCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.DeleteCustomerResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -78,12 +80,13 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - customerId: The unique identifier of the customer to update.
     ///   - request: The fields to update on the customer record.
     /// - Returns: A tuple containing the updated ``FrameObjects/Customer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateCustomerWith(customerId: String, request: CustomerRequest.UpdateCustomerRequest) async throws -> (FrameObjects.Customer?, NetworkingError?) {
         guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.updateCustomer(customerId: customerId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -97,10 +100,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve; pass `nil` to use the API default.
     ///   - perPage: The number of results per page; pass `nil` to use the API default.
     /// - Returns: A tuple containing a ``CustomerResponses/ListCustomersResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getCustomers(page: Int? = nil, perPage: Int? = nil) async throws -> (CustomerResponses.ListCustomersResponse?, NetworkingError?) {
         let endpoint = CustomerEndpoints.getCustomers(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -114,11 +118,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - customerId: The unique identifier of the customer to retrieve.
     ///   - forTesting: Pass `true` to skip Sift login-event collection; defaults to `false`.
     /// - Returns: A tuple containing the matching ``FrameObjects/Customer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getCustomerWith(customerId: String, forTesting: Bool = false) async throws -> (FrameObjects.Customer?, NetworkingError?) {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.getCustomerWith(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
@@ -133,11 +138,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The search parameters used to filter customers.
     /// - Returns: A tuple containing an array of matching ``FrameObjects/Customer`` objects on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func searchCustomers(request: CustomerRequest.SearchCustomersRequest) async throws -> ([FrameObjects.Customer]?, NetworkingError?) {
         let endpoint = CustomerEndpoints.searchCustomers
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
             return (decodedResponse.data, error)
         } else {
@@ -149,11 +155,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///
     /// - Parameter customerId: The unique identifier of the customer to block.
     /// - Returns: A tuple containing the updated ``FrameObjects/Customer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func blockCustomerWith(customerId: String) async throws -> (FrameObjects.Customer?, NetworkingError?) {
         guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.blockCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -165,11 +172,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///
     /// - Parameter customerId: The unique identifier of the customer to unblock.
     /// - Returns: A tuple containing the updated ``FrameObjects/Customer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func unblockCustomerWith(customerId: String) async throws -> (FrameObjects.Customer?, NetworkingError?) {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.unblockCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -184,11 +192,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The customer creation parameters.
     ///   - completionHandler: Called with the created ``FrameObjects/Customer`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createCustomer(request: CustomerRequest.CreateCustomerRequest, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.createCustomer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -203,10 +212,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - customerId: The unique identifier of the customer to delete.
     ///   - completionHandler: Called with a ``CustomerResponses/DeleteCustomerResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteCustomer(customerId: String, completionHandler: @escaping @Sendable (CustomerResponses.DeleteCustomerResponse?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.deleteCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.DeleteCustomerResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -221,11 +231,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - customerId: The unique identifier of the customer to update.
     ///   - request: The fields to update on the customer record.
     ///   - completionHandler: Called with the updated ``FrameObjects/Customer`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateCustomerWith(customerId: String, request: CustomerRequest.UpdateCustomerRequest, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.updateCustomer(customerId: customerId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -240,10 +251,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve; pass `nil` to use the API default.
     ///   - perPage: The number of results per page; pass `nil` to use the API default.
     ///   - completionHandler: Called with a ``CustomerResponses/ListCustomersResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getCustomers(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (CustomerResponses.ListCustomersResponse?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.getCustomers(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -257,10 +269,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - customerId: The unique identifier of the customer to retrieve.
     ///   - completionHandler: Called with the matching ``FrameObjects/Customer`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.getCustomerWith(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -275,11 +288,12 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The search parameters used to filter customers.
     ///   - completionHandler: Called with an array of matching ``FrameObjects/Customer`` objects or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func searchCustomers(request: CustomerRequest.SearchCustomersRequest, completionHandler: @escaping @Sendable ([FrameObjects.Customer]?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.searchCustomers
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
                 completionHandler(decodedResponse.data, error)
             } else {
@@ -293,10 +307,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - customerId: The unique identifier of the customer to block.
     ///   - completionHandler: Called with the updated ``FrameObjects/Customer`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func blockCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.blockCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -310,10 +325,11 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - customerId: The unique identifier of the customer to unblock.
     ///   - completionHandler: Called with the updated ``FrameObjects/Customer`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func unblockCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.unblockCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Customers/CustomersAPI.swift
+++ b/Sources/Frame/Networking/Customers/CustomersAPI.swift
@@ -46,7 +46,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.createCustomer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
@@ -66,7 +66,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.deleteCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.DeleteCustomerResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -86,7 +86,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.updateCustomer(customerId: customerId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -104,7 +104,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func getCustomers(page: Int? = nil, perPage: Int? = nil) async throws -> (CustomerResponses.ListCustomersResponse?, NetworkingError?) {
         let endpoint = CustomerEndpoints.getCustomers(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -123,7 +123,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.getCustomerWith(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             if !forTesting {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
@@ -143,7 +143,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.searchCustomers
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
             return (decodedResponse.data, error)
         } else {
@@ -160,7 +160,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.blockCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -177,7 +177,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
        guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = CustomerEndpoints.unblockCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -197,7 +197,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.createCustomer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -216,7 +216,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func deleteCustomer(customerId: String, completionHandler: @escaping @Sendable (CustomerResponses.DeleteCustomerResponse?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.deleteCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.DeleteCustomerResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -236,7 +236,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.updateCustomer(customerId: customerId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -255,7 +255,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func getCustomers(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (CustomerResponses.ListCustomersResponse?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.getCustomers(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -273,7 +273,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func getCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.getCustomerWith(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: decodedResponse.id, email: decodedResponse.email ?? "")
                 completionHandler(decodedResponse, error)
@@ -293,7 +293,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
         let endpoint = CustomerEndpoints.searchCustomers
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(CustomerResponses.ListCustomersResponse.self, from: data) {
                 completionHandler(decodedResponse.data, error)
             } else {
@@ -311,7 +311,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func blockCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.blockCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -329,7 +329,7 @@ public class CustomersAPI: CustomersProtocol, @unchecked Sendable {
     public static func unblockCustomerWith(customerId: String, completionHandler: @escaping @Sendable (FrameObjects.Customer?, NetworkingError?) -> Void) {
         let endpoint = CustomerEndpoints.unblockCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Customer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationAPI.swift
+++ b/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationAPI.swift
@@ -36,7 +36,7 @@ public class DeviceAttestationAPI: DeviceAttestationProtocol, @unchecked Sendabl
         let endpoint = DeviceAttestationEndpoints.challenge
         let (data, error) = try await FrameNetworking.shared.performDataTask(
             endpoint: endpoint,
-            usePublishableKey: true
+            auth: .publishable
         )
         if let data,
            let decoded = try? FrameNetworking.shared.jsonDecoder.decode(
@@ -67,7 +67,7 @@ public class DeviceAttestationAPI: DeviceAttestationProtocol, @unchecked Sendabl
         let (data, error) = try await FrameNetworking.shared.performDataTask(
             endpoint: endpoint,
             requestBody: requestBody,
-            usePublishableKey: true
+            auth: .publishable
         )
         if let data,
            let decoded = try? FrameNetworking.shared.jsonDecoder.decode(
@@ -87,7 +87,7 @@ public class DeviceAttestationAPI: DeviceAttestationProtocol, @unchecked Sendabl
     public static func getChallenge(completionHandler: @escaping @Sendable (DeviceAttestationRequests.ChallengeResponse?, NetworkingError?) -> Void) {
         let endpoint = DeviceAttestationEndpoints.challenge
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, usePublishableKey: true) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable) { data, response, error in
             if let data,
                let decoded = try? FrameNetworking.shared.jsonDecoder.decode(
                    DeviceAttestationRequests.ChallengeResponse.self, from: data
@@ -117,7 +117,7 @@ public class DeviceAttestationAPI: DeviceAttestationProtocol, @unchecked Sendabl
         )
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, usePublishableKey: true) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable) { data, response, error in
             if let data,
                let decoded = try? FrameNetworking.shared.jsonDecoder.decode(
                    DeviceAttestationRequests.AttestResponse.self, from: data

--- a/Sources/Frame/Networking/Disputes/DisputesAPI.swift
+++ b/Sources/Frame/Networking/Disputes/DisputesAPI.swift
@@ -36,11 +36,12 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - disputeId: The unique identifier of the dispute to update.
     ///   - request: The update request body containing fields to modify.
     /// - Returns: A tuple of the updated ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateDispute(disputeId: String, request: DisputeRequests.UpdateDisputeRequest) async throws -> (FrameObjects.Dispute?, NetworkingError?) {
         let endpoint = DisputeEndpoints.updateDispute(disputeId: disputeId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -52,10 +53,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///
     /// - Parameter disputeId: The unique identifier of the dispute to retrieve.
     /// - Returns: A tuple of the fetched ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getDispute(disputeId: String) async throws -> (FrameObjects.Dispute?, NetworkingError?) {
         let endpoint = DisputeEndpoints.getDispute(disputeId: disputeId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -71,10 +73,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - perPage: The number of results to return per page. Defaults to `10`.
     ///   - page: The page number to retrieve. Defaults to `1`.
     /// - Returns: A tuple of the ``DisputeResponses/ListDisputesResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getDisputes(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int = 10, page: Int = 1) async throws -> (DisputeResponses.ListDisputesResponse?, NetworkingError?) {
         let endpoint = DisputeEndpoints.getDisputes(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(DisputeResponses.ListDisputesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -86,10 +89,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///
     /// - Parameter disputeId: The unique identifier of the dispute to close.
     /// - Returns: A tuple of the closed ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func closeDispute(disputeId: String) async throws -> (FrameObjects.Dispute?, NetworkingError?) {
         let endpoint = DisputeEndpoints.closeDispute(disputeId: disputeId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -103,10 +107,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - disputeId: The unique identifier of the dispute to attach documents to.
     ///   - files: An array of ``FileUpload`` values representing the documents to upload.
     /// - Returns: An optional ``NetworkingError`` if the upload failed.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func uploadDocuments(disputeId: String, files: [FileUpload]) async throws -> NetworkingError? {
         guard !disputeId.isEmpty else { return nil }
         let endpoint = DisputeEndpoints.uploadDocuments(disputeId: disputeId)
-        let (_, error) = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files)
+        let (_, error) = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files, auth: .secret)
         return error
     }
 
@@ -118,11 +123,12 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - disputeId: The unique identifier of the dispute to update.
     ///   - request: The update request body containing fields to modify.
     ///   - completionHandler: Called with the updated ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateDispute(disputeId: String, request: DisputeRequests.UpdateDisputeRequest, completionHandler: @escaping @Sendable (FrameObjects.Dispute?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.updateDispute(disputeId: disputeId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -136,10 +142,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - disputeId: The unique identifier of the dispute to retrieve.
     ///   - completionHandler: Called with the fetched ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getDispute(disputeId: String, completionHandler: @escaping @Sendable (FrameObjects.Dispute?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.getDispute(disputeId: disputeId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -156,10 +163,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - perPage: The number of results to return per page. Defaults to `10`.
     ///   - page: The page number to retrieve. Defaults to `1`.
     ///   - completionHandler: Called with the ``DisputeResponses/ListDisputesResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getDisputes(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int = 10, page: Int = 1, completionHandler: @escaping @Sendable (DisputeResponses.ListDisputesResponse?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.getDisputes(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(DisputeResponses.ListDisputesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -173,10 +181,11 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - disputeId: The unique identifier of the dispute to close.
     ///   - completionHandler: Called with the closed ``FrameObjects/Dispute`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func closeDispute(disputeId: String, completionHandler: @escaping @Sendable (FrameObjects.Dispute?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.closeDispute(disputeId: disputeId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -191,11 +200,12 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     ///   - disputeId: The unique identifier of the dispute to attach documents to.
     ///   - files: An array of ``FileUpload`` values representing the documents to upload.
     ///   - completionHandler: Called with an optional ``NetworkingError`` if the upload failed.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func uploadDocuments(disputeId: String, files: [FileUpload], completionHandler: @escaping @Sendable (NetworkingError?) -> Void) {
         guard !disputeId.isEmpty else { return completionHandler(nil) }
         let endpoint = DisputeEndpoints.uploadDocuments(disputeId: disputeId)
 
-        FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files) { _, _, error in
+        FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files, auth: .secret) { _, _, error in
             completionHandler(error)
         }
     }

--- a/Sources/Frame/Networking/Disputes/DisputesAPI.swift
+++ b/Sources/Frame/Networking/Disputes/DisputesAPI.swift
@@ -41,7 +41,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
         let endpoint = DisputeEndpoints.updateDispute(disputeId: disputeId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -57,7 +57,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func getDispute(disputeId: String) async throws -> (FrameObjects.Dispute?, NetworkingError?) {
         let endpoint = DisputeEndpoints.getDispute(disputeId: disputeId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -77,7 +77,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func getDisputes(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int = 10, page: Int = 1) async throws -> (DisputeResponses.ListDisputesResponse?, NetworkingError?) {
         let endpoint = DisputeEndpoints.getDisputes(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(DisputeResponses.ListDisputesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -93,7 +93,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func closeDispute(disputeId: String) async throws -> (FrameObjects.Dispute?, NetworkingError?) {
         let endpoint = DisputeEndpoints.closeDispute(disputeId: disputeId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -111,7 +111,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func uploadDocuments(disputeId: String, files: [FileUpload]) async throws -> NetworkingError? {
         guard !disputeId.isEmpty else { return nil }
         let endpoint = DisputeEndpoints.uploadDocuments(disputeId: disputeId)
-        let (_, error) = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files, auth: .secret)
+        let (_, error) = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files)
         return error
     }
 
@@ -128,7 +128,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
         let endpoint = DisputeEndpoints.updateDispute(disputeId: disputeId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -146,7 +146,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func getDispute(disputeId: String, completionHandler: @escaping @Sendable (FrameObjects.Dispute?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.getDispute(disputeId: disputeId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -167,7 +167,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func getDisputes(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int = 10, page: Int = 1, completionHandler: @escaping @Sendable (DisputeResponses.ListDisputesResponse?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.getDisputes(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(DisputeResponses.ListDisputesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -185,7 +185,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
     public static func closeDispute(disputeId: String, completionHandler: @escaping @Sendable (FrameObjects.Dispute?, NetworkingError?) -> Void) {
         let endpoint = DisputeEndpoints.closeDispute(disputeId: disputeId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Dispute.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -205,7 +205,7 @@ public class DisputesAPI: DisputesProtocol, @unchecked Sendable {
         guard !disputeId.isEmpty else { return completionHandler(nil) }
         let endpoint = DisputeEndpoints.uploadDocuments(disputeId: disputeId)
 
-        FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files, auth: .secret) { _, _, error in
+        FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: files) { _, _, error in
             completionHandler(error)
         }
     }

--- a/Sources/Frame/Networking/FrameNetworking.swift
+++ b/Sources/Frame/Networking/FrameNetworking.swift
@@ -18,8 +18,9 @@ import Sift
 /// Central networking hub for the Frame SDK, responsible for authenticating and dispatching
 /// all HTTP requests to the Frame Payments API.
 ///
-/// Obtain the singleton via ``shared`` and call ``initializeWithAPIKey(_:publishableKey:applePayMerchantId:theme:debugMode:)``
-/// once at app launch before using any other SDK API.
+/// Obtain the singleton via ``shared`` and call ``initialize(publishableKey:secretKey:applePayMerchantId:theme:debugMode:)``
+/// once at app launch before using any other SDK API. The SDK is publishable-key first: pass your
+/// publishable key (`pk_`) and serve any secret key from your backend.
 public class FrameNetworking: ObservableObject {
     /// The shared singleton instance used by all SDK components.
     nonisolated(unsafe) public static let shared = FrameNetworking()
@@ -32,9 +33,18 @@ public class FrameNetworking: ObservableObject {
     var asyncURLSession: URLSessionProtocol = URLSession.shared
     var urlSession: URLSession = URLSession.shared
 
-    private var apiSecretKey: String = "" // API Key used to authenticate each request - Bearer Token
-    private var apiPublishableKey: String = "" // Publishable key for client-side only endpoints
+    private var apiSecretKey: String = "" // Secret key (sk_). Server-only; avoid shipping in an app binary.
+    private var apiPublishableKey: String = "" // Publishable key (pk_). Default credential for client-safe endpoints.
     private var debugMode: Bool = false // Print API data on task calls.
+
+    /// Tracks whether the one-time secret-key usage warning has already been emitted.
+    private var hasWarnedAboutSecretKeyUsage = false
+
+    /// The active onboarding-session client secret (`onb_sess_…`), if an onboarding flow is in progress.
+    ///
+    /// While set, every request authenticates with this token instead of `pk_`/`sk_`, scoping the
+    /// onboarding flow to a single account (see ``beginOnboardingSession(clientSecret:)``).
+    private var onboardingSessionToken: String?
 
     var isEvervaultConfigured: Bool = false
 
@@ -45,24 +55,35 @@ public class FrameNetworking: ObservableObject {
     /// Apple Pay merchant identifier, captured at SDK init and read by every Apple Pay surface.
     public private(set) var applePayMerchantId: String?
 
-    /// Initializes the SDK with the provided credentials and configuration.
+    /// Initializes the SDK with a publishable key (`pk_`) and configuration.
     ///
-    /// Call this method once, early in the app lifecycle (e.g. `application(_:didFinishLaunchingWithOptions:)`),
-    /// before making any other SDK calls.
+    /// This is the recommended entry point. Call it once, early in the app lifecycle
+    /// (e.g. `application(_:didFinishLaunchingWithOptions:)`), before making any other SDK calls.
+    ///
+    /// The publishable key is the SDK's default credential and is safe to embed in an app
+    /// binary. Only pass a secret key (`secretKey:`) if you must call a server-only endpoint
+    /// from the app — and prefer serving that key from your own backend instead.
     ///
     /// - Parameters:
-    ///   - key: Your Frame Payments secret API key used to authenticate server-side requests.
-    ///   - publishableKey: Your Frame Payments publishable key used for client-side-only endpoints.
+    ///   - publishableKey: Your Frame Payments publishable key (`pk_`). Used for all client-safe endpoints.
+    ///   - secretKey: Optional secret key (`sk_`). Server-only; avoid shipping it in an app binary. Defaults to `nil`.
     ///   - applePayMerchantId: Optional Apple Pay merchant identifier required to present Apple Pay sheets.
     ///   - theme: Visual theme applied to all Frame SDK UI. Defaults to ``FrameTheme/default``.
     ///   - debugMode: When `true`, request and response bodies are printed to the console. Defaults to `false`.
-    public func initializeWithAPIKey(_ key: String,
-                                     publishableKey: String,
-                                     applePayMerchantId: String? = nil,
-                                     theme: FrameTheme = .default,
-                                     debugMode: Bool = false) {
-        self.apiSecretKey = key
+    public func initialize(publishableKey: String,
+                           secretKey: String? = nil,
+                           applePayMerchantId: String? = nil,
+                           theme: FrameTheme = .default,
+                           debugMode: Bool = false) {
+        if publishableKey.hasPrefix("sk_") {
+            warnSecretKeyMisuse(context: "passed as the publishableKey")
+        }
+        if let secretKey, !secretKey.isEmpty {
+            warnSecretKeyMisuse(context: "configured via secretKey")
+        }
+
         self.apiPublishableKey = publishableKey
+        self.apiSecretKey = secretKey ?? ""
         self.applePayMerchantId = applePayMerchantId
         self.debugMode = debugMode
 
@@ -85,6 +106,107 @@ public class FrameNetworking: ObservableObject {
         }
     }
 
+    /// Initializes the SDK with the provided credentials and configuration.
+    ///
+    /// - Important: This signature leads with the secret key and is retained only for source
+    ///   compatibility. Prefer ``initialize(publishableKey:secretKey:applePayMerchantId:theme:debugMode:)``,
+    ///   which is publishable-key first.
+    ///
+    /// - Parameters:
+    ///   - key: Your Frame Payments secret API key. Server-only; avoid shipping it in an app binary.
+    ///   - publishableKey: Your Frame Payments publishable key used for client-side-only endpoints.
+    ///   - applePayMerchantId: Optional Apple Pay merchant identifier required to present Apple Pay sheets.
+    ///   - theme: Visual theme applied to all Frame SDK UI. Defaults to ``FrameTheme/default``.
+    ///   - debugMode: When `true`, request and response bodies are printed to the console. Defaults to `false`.
+    @available(*, deprecated, message: "Use initialize(publishableKey:secretKey:applePayMerchantId:theme:debugMode:). Secret keys must not ship in an app binary — serve sk_ from your backend.")
+    public func initializeWithAPIKey(_ key: String,
+                                     publishableKey: String,
+                                     applePayMerchantId: String? = nil,
+                                     theme: FrameTheme = .default,
+                                     debugMode: Bool = false) {
+        initialize(publishableKey: publishableKey,
+                   secretKey: key,
+                   applePayMerchantId: applePayMerchantId,
+                   theme: theme,
+                   debugMode: debugMode)
+    }
+
+    /// Begins an onboarding session, binding all subsequent SDK requests to the given
+    /// onboarding-session client secret (`onb_sess_…`).
+    ///
+    /// The integrator's server creates the onboarding session (`POST /v1/onboarding_sessions`) and
+    /// hands the resulting `onb_sess_…` token to the app. While a session is active, every request
+    /// authenticates with this token instead of `pk_`/`sk_`, which scopes the flow to a single
+    /// account (a bare publishable key would allow cross-account access). Call
+    /// ``endOnboardingSession()`` when the onboarding flow completes or is dismissed.
+    ///
+    /// - Parameter clientSecret: The onboarding-session token (`onb_sess_…`).
+    public func beginOnboardingSession(clientSecret: String) {
+        onboardingSessionToken = clientSecret
+    }
+
+    /// Ends the active onboarding session, restoring normal `pk_`/`sk_` authentication.
+    public func endOnboardingSession() {
+        onboardingSessionToken = nil
+    }
+
+    /// Resolves the Bearer token for a request based on its ``FrameAuthMode``.
+    ///
+    /// While an onboarding session is active (see ``beginOnboardingSession(clientSecret:)``), the
+    /// onboarding-session token takes precedence for every request, scoping the flow to one account.
+    /// Otherwise, emits a one-time warning the first time the secret key is used, steering
+    /// integrators toward serving `sk_` from their backend.
+    private func bearerToken(for auth: FrameAuthMode) -> String {
+        // An explicit per-call client secret always wins (e.g. a charge intent's client_secret).
+        if case .clientSecret(let token) = auth {
+            return token
+        }
+
+        // During onboarding, every request is authenticated by the onboarding-session token.
+        if let onboardingSessionToken {
+            return onboardingSessionToken
+        }
+
+        switch auth {
+        case .publishable:
+            if apiPublishableKey.isEmpty {
+                warnOnce(&hasMissingPublishableKeyWarned,
+                         "⚠️ Frame: a client-safe request was made but no publishable key (pk_) is configured. Call initialize(publishableKey:) first.")
+            }
+            return apiPublishableKey
+        case .secret:
+            // A secret key actually leaving the device on a live request is the most actionable
+            // misuse; warn on it independently of the init-time configuration warning.
+            warnOnce(&hasWarnedAboutSecretKeyRequest,
+                     secretKeyWarning(context: "used to authenticate a request from the app"))
+            return apiSecretKey
+        case .clientSecret:
+            // Handled by the early return above; unreachable here.
+            return ""
+        }
+    }
+
+    /// Set once a missing-publishable-key warning has been emitted.
+    private var hasMissingPublishableKeyWarned = false
+
+    /// Set once the secret key has been used to authenticate a live request.
+    private var hasWarnedAboutSecretKeyRequest = false
+
+    private func warnSecretKeyMisuse(context: String) {
+        warnOnce(&hasWarnedAboutSecretKeyUsage, secretKeyWarning(context: context))
+    }
+
+    private func secretKeyWarning(context: String) -> String {
+        "⚠️ Frame: a secret key (sk_) was \(context). Secret keys grant full merchant privileges and must never ship in an app binary, where they can be extracted by reverse-engineering. Serve sk_ from your backend and pass only your publishable key (pk_) to the SDK."
+    }
+
+    /// Prints `message` to the console the first time `flag` is `false`, then sets it `true`.
+    private func warnOnce(_ flag: inout Bool, _ message: String) {
+        guard !flag else { return }
+        flag = true
+        print(message)
+    }
+
     func currentSonarSessionId() -> String? {
         SonarSessionStorage.currentSessionId()
     }
@@ -95,9 +217,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - requestBody: Optional JSON-encoded body data to include in the request.
-    ///   - usePublishableKey: When `true`, the publishable key is used instead of the secret key. Defaults to `false`.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
     /// - Returns: A tuple of the raw response `Data` (if any) and a ``NetworkingError`` (if the request failed).
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, usePublishableKey: Bool = false) async throws -> (Data?, NetworkingError?) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .publishable) async throws -> (Data?, NetworkingError?) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return (nil, nil) }
 
         var urlRequest = URLRequest(url: url)
@@ -111,8 +233,7 @@ public class FrameNetworking: ObservableObject {
             urlRequest.url?.append(queryItems: queryItems)
         }
 
-        let authKey = usePublishableKey && !apiPublishableKey.isEmpty ? apiPublishableKey : apiSecretKey
-        urlRequest.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(bearerToken(for: auth))", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         if let ipAddress = SiftManager.getIPAddress() {
             urlRequest.setValue(SiftManager.getIPAddress(), forHTTPHeaderField: "ip_address")
@@ -143,8 +264,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - filesToUpload: An array of ``FileUpload`` values describing each file part to include in the request.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
     /// - Returns: A tuple of the raw response `Data` (if any) and a ``NetworkingError`` (if the request failed).
-    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload]) async throws -> (Data?, NetworkingError?) {
+    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .publishable) async throws -> (Data?, NetworkingError?) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return (nil, nil) }
 
         let multipart = MultipartFormDataBuilder()
@@ -170,7 +292,7 @@ public class FrameNetworking: ObservableObject {
         urlRequest.httpBody = body
         urlRequest.setValue(multipart.contentTypeHeader, forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
-        urlRequest.setValue("Bearer \(apiSecretKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(bearerToken(for: auth))", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
         if let ipAddress = SiftManager.getIPAddress() {
             urlRequest.setValue(SiftManager.getIPAddress(), forHTTPHeaderField: "ip_address")
@@ -197,14 +319,14 @@ public class FrameNetworking: ObservableObject {
     }
 
     // Completion Handler
-    /// Completion-handler variant of ``performDataTask(endpoint:requestBody:usePublishableKey:)``.
+    /// Completion-handler variant of ``performDataTask(endpoint:requestBody:auth:)``.
     ///
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - requestBody: Optional JSON-encoded body data to include in the request.
-    ///   - usePublishableKey: When `true`, the publishable key is used instead of the secret key. Defaults to `false`.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
     ///   - completion: Called on task completion with the raw `Data`, the `URLResponse`, and an optional ``NetworkingError``.
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, usePublishableKey: Bool = false, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .publishable, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return completion(nil, nil, nil) }
 
         var urlRequest = URLRequest(url: url)
@@ -218,8 +340,7 @@ public class FrameNetworking: ObservableObject {
             urlRequest.url?.append(queryItems: queryItems)
         }
 
-        let authKey = usePublishableKey && !apiPublishableKey.isEmpty ? apiPublishableKey : apiSecretKey
-        urlRequest.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(bearerToken(for: auth))", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
 
         if let ipAddress = SiftManager.getIPAddress() {
@@ -253,8 +374,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - filesToUpload: An array of ``FileUpload`` values describing each file part to include in the request.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
     ///   - completion: Called on task completion with the raw `Data`, the `URLResponse`, and an optional ``NetworkingError``.
-    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
+    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .publishable, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return completion(nil, nil, nil) }
 
         let multipart = MultipartFormDataBuilder()
@@ -280,7 +402,7 @@ public class FrameNetworking: ObservableObject {
         urlRequest.httpBody = body
         urlRequest.setValue(multipart.contentTypeHeader, forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
-        urlRequest.setValue("Bearer \(apiSecretKey)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("Bearer \(bearerToken(for: auth))", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("iOS", forHTTPHeaderField: "User-Agent")
 
         if let ipAddress = SiftManager.getIPAddress() {

--- a/Sources/Frame/Networking/FrameNetworking.swift
+++ b/Sources/Frame/Networking/FrameNetworking.swift
@@ -227,9 +227,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - requestBody: Optional JSON-encoded body data to include in the request.
-    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/secret``.
     /// - Returns: A tuple of the raw response `Data` (if any) and a ``NetworkingError`` (if the request failed).
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .publishable) async throws -> (Data?, NetworkingError?) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .secret) async throws -> (Data?, NetworkingError?) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return (nil, nil) }
 
         var urlRequest = URLRequest(url: url)
@@ -274,9 +274,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - filesToUpload: An array of ``FileUpload`` values describing each file part to include in the request.
-    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/secret``.
     /// - Returns: A tuple of the raw response `Data` (if any) and a ``NetworkingError`` (if the request failed).
-    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .publishable) async throws -> (Data?, NetworkingError?) {
+    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .secret) async throws -> (Data?, NetworkingError?) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return (nil, nil) }
 
         let multipart = MultipartFormDataBuilder()
@@ -334,9 +334,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - requestBody: Optional JSON-encoded body data to include in the request.
-    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/secret``.
     ///   - completion: Called on task completion with the raw `Data`, the `URLResponse`, and an optional ``NetworkingError``.
-    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .publishable, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
+    public func performDataTask(endpoint: FrameNetworkingEndpoints, requestBody: Data? = nil, auth: FrameAuthMode = .secret, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return completion(nil, nil, nil) }
 
         var urlRequest = URLRequest(url: url)
@@ -384,9 +384,9 @@ public class FrameNetworking: ObservableObject {
     /// - Parameters:
     ///   - endpoint: The ``FrameNetworkingEndpoints`` value that specifies the URL path, HTTP method, and query items.
     ///   - filesToUpload: An array of ``FileUpload`` values describing each file part to include in the request.
-    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/publishable``.
+    ///   - auth: Which credential authenticates the request. Defaults to ``FrameAuthMode/secret``.
     ///   - completion: Called on task completion with the raw `Data`, the `URLResponse`, and an optional ``NetworkingError``.
-    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .publishable, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
+    public func performMultipartDataTask(endpoint: FrameNetworkingEndpoints, filesToUpload: [FileUpload], auth: FrameAuthMode = .secret, completion: @escaping @Sendable (Data?, URLResponse?, NetworkingError?) -> Void) {
         guard let url = URL(string: NetworkingConstants.mainAPIURL + endpoint.endpointURL) else { return completion(nil, nil, nil) }
 
         let multipart = MultipartFormDataBuilder()

--- a/Sources/Frame/Networking/FrameNetworking.swift
+++ b/Sources/Frame/Networking/FrameNetworking.swift
@@ -142,6 +142,13 @@ public class FrameNetworking: ObservableObject {
     ///
     /// - Parameter clientSecret: The onboarding-session token (`onb_sess_…`).
     public func beginOnboardingSession(clientSecret: String) {
+        if !clientSecret.hasPrefix("onb_sess_") {
+            warnOnce(&hasWarnedAboutOnboardingTokenPrefix,
+                     "⚠️ Frame: beginOnboardingSession was called with a token that is not an onboarding-session "
+                     + "token (onb_sess_…). Onboarding requests authenticate with this value verbatim, so a publishable "
+                     + "key, secret key, or charge-intent client secret will not scope the flow to an account and may be "
+                     + "rejected. Mint the token from your backend via POST /v1/onboarding_sessions.")
+        }
         onboardingSessionToken = clientSecret
     }
 
@@ -191,6 +198,9 @@ public class FrameNetworking: ObservableObject {
 
     /// Set once the secret key has been used to authenticate a live request.
     private var hasWarnedAboutSecretKeyRequest = false
+
+    /// Set once a non-`onb_sess_` onboarding token warning has been emitted.
+    private var hasWarnedAboutOnboardingTokenPrefix = false
 
     private func warnSecretKeyMisuse(context: String) {
         warnOnce(&hasWarnedAboutSecretKeyUsage, secretKeyWarning(context: context))

--- a/Sources/Frame/Networking/InvoiceLineItems/InvoiceLineItemsAPI.swift
+++ b/Sources/Frame/Networking/InvoiceLineItems/InvoiceLineItemsAPI.swift
@@ -54,7 +54,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItems(invoiceId: String) async throws -> (InvoiceLineItemResponses.ListLineItemsResponse?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.getLineItems(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.ListLineItemsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -73,7 +73,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
         let endpoint = InvoiceLineItemEndpoints.createLineItem(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -93,7 +93,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
         let endpoint = InvoiceLineItemEndpoints.updateLineItem(invoiceId: invoiceId, itemId: itemId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -110,7 +110,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItem(invoiceId: String, itemId: String) async throws -> (FrameObjects.InvoiceLineItem?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.getLineItem(invoiceId: invoiceId, itemId: itemId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -127,7 +127,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteLineItem(invoiceId: String, itemId: String) async throws -> (InvoiceLineItemResponses.DeleteLineItemResponse?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.deleteLineItem(invoiceId: invoiceId, itemId: itemId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.DeleteLineItemResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -146,7 +146,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     public static func getLineItems(invoiceId: String, completionHandler: @escaping @Sendable (InvoiceLineItemResponses.ListLineItemsResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.getLineItems(invoiceId: invoiceId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.ListLineItemsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -166,7 +166,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
         let endpoint = InvoiceLineItemEndpoints.createLineItem(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -187,7 +187,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
         let endpoint = InvoiceLineItemEndpoints.updateLineItem(invoiceId: invoiceId, itemId: itemId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -206,7 +206,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     public static func getLineItem(invoiceId: String, itemId: String, completionHandler: @escaping @Sendable (FrameObjects.InvoiceLineItem?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.getLineItem(invoiceId: invoiceId, itemId: itemId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -225,7 +225,7 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     public static func deleteLineItem(invoiceId: String, itemId: String, completionHandler: @escaping @Sendable (InvoiceLineItemResponses.DeleteLineItemResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.deleteLineItem(invoiceId: invoiceId, itemId: itemId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.DeleteLineItemResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/InvoiceLineItems/InvoiceLineItemsAPI.swift
+++ b/Sources/Frame/Networking/InvoiceLineItems/InvoiceLineItemsAPI.swift
@@ -51,9 +51,10 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///
     /// - Parameter invoiceId: The unique identifier of the invoice whose line items should be fetched.
     /// - Returns: A tuple containing the paginated list response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItems(invoiceId: String) async throws -> (InvoiceLineItemResponses.ListLineItemsResponse?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.getLineItems(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.ListLineItemsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -67,11 +68,12 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice to which the line item will be added.
     ///   - request: The request body containing the details of the line item to create.
     /// - Returns: A tuple containing the created ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createLineItem(invoiceId: String, request: InvoiceLineItemRequests.CreateLineItemRequest) async throws -> (FrameObjects.InvoiceLineItem?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.createLineItem(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -86,11 +88,12 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - itemId: The unique identifier of the line item to update.
     ///   - request: The request body containing the fields to update on the line item.
     /// - Returns: A tuple containing the updated ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateLineItem(invoiceId: String, itemId: String, request: InvoiceLineItemRequests.UpdateLineItemRequest) async throws -> (FrameObjects.InvoiceLineItem?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.updateLineItem(invoiceId: invoiceId, itemId: itemId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -104,9 +107,10 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice that owns the line item.
     ///   - itemId: The unique identifier of the line item to retrieve.
     /// - Returns: A tuple containing the ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItem(invoiceId: String, itemId: String) async throws -> (FrameObjects.InvoiceLineItem?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.getLineItem(invoiceId: invoiceId, itemId: itemId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -120,9 +124,10 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice that owns the line item.
     ///   - itemId: The unique identifier of the line item to delete.
     /// - Returns: A tuple containing the deletion confirmation response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteLineItem(invoiceId: String, itemId: String) async throws -> (InvoiceLineItemResponses.DeleteLineItemResponse?, NetworkingError?) {
         let endpoint = InvoiceLineItemEndpoints.deleteLineItem(invoiceId: invoiceId, itemId: itemId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.DeleteLineItemResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -137,10 +142,11 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     /// - Parameters:
     ///   - invoiceId: The unique identifier of the invoice whose line items should be fetched.
     ///   - completionHandler: Called with the paginated list response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItems(invoiceId: String, completionHandler: @escaping @Sendable (InvoiceLineItemResponses.ListLineItemsResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.getLineItems(invoiceId: invoiceId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.ListLineItemsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -155,11 +161,12 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice to which the line item will be added.
     ///   - request: The request body containing the details of the line item to create.
     ///   - completionHandler: Called with the created ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createLineItem(invoiceId: String, request: InvoiceLineItemRequests.CreateLineItemRequest, completionHandler: @escaping @Sendable (FrameObjects.InvoiceLineItem?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.createLineItem(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -175,11 +182,12 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - itemId: The unique identifier of the line item to update.
     ///   - request: The request body containing the fields to update on the line item.
     ///   - completionHandler: Called with the updated ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateLineItem(invoiceId: String, itemId: String, request: InvoiceLineItemRequests.UpdateLineItemRequest, completionHandler: @escaping @Sendable (FrameObjects.InvoiceLineItem?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.updateLineItem(invoiceId: invoiceId, itemId: itemId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -194,10 +202,11 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice that owns the line item.
     ///   - itemId: The unique identifier of the line item to retrieve.
     ///   - completionHandler: Called with the ``FrameObjects/InvoiceLineItem`` and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getLineItem(invoiceId: String, itemId: String, completionHandler: @escaping @Sendable (FrameObjects.InvoiceLineItem?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.getLineItem(invoiceId: invoiceId, itemId: itemId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.InvoiceLineItem.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -212,10 +221,11 @@ public class InvoiceLineItemsAPI: InvoiceLineItemProtocol {
     ///   - invoiceId: The unique identifier of the invoice that owns the line item.
     ///   - itemId: The unique identifier of the line item to delete.
     ///   - completionHandler: Called with the deletion confirmation response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteLineItem(invoiceId: String, itemId: String, completionHandler: @escaping @Sendable (InvoiceLineItemResponses.DeleteLineItemResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceLineItemEndpoints.deleteLineItem(invoiceId: invoiceId, itemId: itemId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceLineItemResponses.DeleteLineItemResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Invoices/InvoicesAPI.swift
+++ b/Sources/Frame/Networking/Invoices/InvoicesAPI.swift
@@ -40,7 +40,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
         let endpoint = InvoiceEndpoints.createInvoice
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -59,7 +59,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
         let endpoint = InvoiceEndpoints.updateInvoice(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -78,7 +78,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoices(perPage: Int? = nil, page: Int? = nil, customer: String? = nil, status: FrameObjects.InvoiceStatus? = nil)  async throws -> (InvoiceResponses.ListInvoicesResponse?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.getInvoices(perPage: perPage, page: page, customer: customer, status: status)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.ListInvoicesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -93,7 +93,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoice(invoiceId: String) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.getInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -108,7 +108,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteInvoice(invoiceId: String) async throws -> (InvoiceResponses.DeleteInvoiceResponse?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.deleteInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.DeleteInvoiceResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -123,7 +123,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func issueInvoice(invoiceId: String) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.issueInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -143,7 +143,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
         let endpoint = InvoiceEndpoints.createInvoice
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -163,7 +163,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
         let endpoint = InvoiceEndpoints.updateInvoice(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -183,7 +183,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoices(perPage: Int?, page: Int?, customer: String?, status: FrameObjects.InvoiceStatus?, completionHandler: @escaping @Sendable (InvoiceResponses.ListInvoicesResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.getInvoices(perPage: perPage, page: page, customer: customer, status: status)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.ListInvoicesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -200,7 +200,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoice(invoiceId: String, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.getInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -217,7 +217,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteInvoice(invoiceId: String, completionHandler: @escaping @Sendable (InvoiceResponses.DeleteInvoiceResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.deleteInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.DeleteInvoiceResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -234,7 +234,7 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func issueInvoice(invoiceId: String, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.issueInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Invoices/InvoicesAPI.swift
+++ b/Sources/Frame/Networking/Invoices/InvoicesAPI.swift
@@ -35,11 +35,12 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The request body containing the invoice fields to set.
     /// - Returns: A tuple of the created ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createInvoice(request: InvoiceRequests.CreateInvoiceRequest) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.createInvoice
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -53,11 +54,12 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///   - invoiceId: The unique identifier of the invoice to update.
     ///   - request: The request body containing the fields to update.
     /// - Returns: A tuple of the updated ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateInvoice(invoiceId: String, request: InvoiceRequests.UpdateInvoiceRequest) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.updateInvoice(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -73,9 +75,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///   - customer: An optional customer ID to filter invoices by.
     ///   - status: An optional ``FrameObjects/InvoiceStatus`` to filter invoices by.
     /// - Returns: A tuple of an ``InvoiceResponses/ListInvoicesResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoices(perPage: Int? = nil, page: Int? = nil, customer: String? = nil, status: FrameObjects.InvoiceStatus? = nil)  async throws -> (InvoiceResponses.ListInvoicesResponse?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.getInvoices(perPage: perPage, page: page, customer: customer, status: status)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.ListInvoicesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -87,9 +90,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///
     /// - Parameter invoiceId: The unique identifier of the invoice to fetch.
     /// - Returns: A tuple of the matching ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoice(invoiceId: String) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.getInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -101,9 +105,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///
     /// - Parameter invoiceId: The unique identifier of the invoice to delete.
     /// - Returns: A tuple of an ``InvoiceResponses/DeleteInvoiceResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteInvoice(invoiceId: String) async throws -> (InvoiceResponses.DeleteInvoiceResponse?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.deleteInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.DeleteInvoiceResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -115,9 +120,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///
     /// - Parameter invoiceId: The unique identifier of the invoice to issue.
     /// - Returns: A tuple of the issued ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func issueInvoice(invoiceId: String) async throws -> (FrameObjects.Invoice?, NetworkingError?) {
         let endpoint = InvoiceEndpoints.issueInvoice(invoiceId: invoiceId)
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -132,11 +138,12 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The request body containing the invoice fields to set.
     ///   - completionHandler: Called with the created ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createInvoice(request: InvoiceRequests.CreateInvoiceRequest, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.createInvoice
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -151,11 +158,12 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///   - invoiceId: The unique identifier of the invoice to update.
     ///   - request: The request body containing the fields to update.
     ///   - completionHandler: Called with the updated ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateInvoice(invoiceId: String, request: InvoiceRequests.UpdateInvoiceRequest, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.updateInvoice(invoiceId: invoiceId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -172,9 +180,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     ///   - customer: An optional customer ID to filter invoices by.
     ///   - status: An optional ``FrameObjects/InvoiceStatus`` to filter invoices by.
     ///   - completionHandler: Called with an ``InvoiceResponses/ListInvoicesResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoices(perPage: Int?, page: Int?, customer: String?, status: FrameObjects.InvoiceStatus?, completionHandler: @escaping @Sendable (InvoiceResponses.ListInvoicesResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.getInvoices(perPage: perPage, page: page, customer: customer, status: status)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.ListInvoicesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -188,9 +197,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - invoiceId: The unique identifier of the invoice to fetch.
     ///   - completionHandler: Called with the matching ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getInvoice(invoiceId: String, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.getInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -204,9 +214,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - invoiceId: The unique identifier of the invoice to delete.
     ///   - completionHandler: Called with an ``InvoiceResponses/DeleteInvoiceResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteInvoice(invoiceId: String, completionHandler: @escaping @Sendable (InvoiceResponses.DeleteInvoiceResponse?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.deleteInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(InvoiceResponses.DeleteInvoiceResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -220,9 +231,10 @@ public class InvoicesAPI: InvoicesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - invoiceId: The unique identifier of the invoice to issue.
     ///   - completionHandler: Called with the issued ``FrameObjects/Invoice`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func issueInvoice(invoiceId: String, completionHandler: @escaping @Sendable (FrameObjects.Invoice?, NetworkingError?) -> Void) {
         let endpoint = InvoiceEndpoints.issueInvoice(invoiceId: invoiceId)
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Invoice.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionEndpoints.swift
+++ b/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionEndpoints.swift
@@ -1,0 +1,34 @@
+//
+//  OnboardingSessionEndpoints.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 6/26/26.
+//
+
+import Foundation
+
+enum OnboardingSessionEndpoints: FrameNetworkingEndpoints {
+    //MARK: Onboarding Session Endpoints
+    case createOnboardingSession
+
+    var endpointURL: String {
+        switch self {
+        case .createOnboardingSession:
+            return "/v1/onboarding_sessions"
+        }
+    }
+
+    var httpMethod: HTTPMethod {
+        switch self {
+        case .createOnboardingSession:
+            return .POST
+        }
+    }
+
+    var queryItems: [URLQueryItem]? {
+        switch self {
+        case .createOnboardingSession:
+            return nil
+        }
+    }
+}

--- a/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionRequests.swift
+++ b/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionRequests.swift
@@ -1,0 +1,54 @@
+//
+//  OnboardingSessionRequests.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 6/26/26.
+//
+
+import Foundation
+
+/// Request body namespace for Onboarding Session API calls.
+///
+/// - Warning: Creating an onboarding session is a **server-only** operation that requires your
+///   secret key (`sk_`). It is exposed here only so the example app can mint a session token for
+///   end-to-end testing. Production integrations must mint the token from their backend
+///   (`POST /v1/onboarding_sessions`) and hand the resulting `onb_sess_…` to the app.
+public class OnboardingSessionRequest {
+
+    /// Request body for creating an onboarding session.
+    public struct CreateOnboardingSessionRequest: Codable {
+        /// The existing Frame account the session onboards.
+        public let accountId: String
+        /// The ordered onboarding steps to present, or `nil` to use the account's defaults.
+        public let steps: [OnboardingSessionStep]?
+        /// Where the account holder is redirected after completing the flow, or `nil`.
+        public let returnUrl: String?
+
+        enum CodingKeys: String, CodingKey {
+            case accountId = "account_id"
+            case steps
+            case returnUrl = "return_url"
+        }
+
+        /// Creates a new onboarding-session request body.
+        /// - Parameters:
+        ///   - accountId: The existing Frame account the session onboards.
+        ///   - steps: The ordered onboarding steps to present, or `nil` for the account defaults.
+        ///   - returnUrl: Redirect destination after completion, or `nil`.
+        public init(accountId: String, steps: [OnboardingSessionStep]? = nil, returnUrl: String? = nil) {
+            self.accountId = accountId
+            self.steps = steps
+            self.returnUrl = returnUrl
+        }
+    }
+
+    /// An onboarding step the session can require.
+    public enum OnboardingSessionStep: String, Codable {
+        /// Identity verification (KYC).
+        case idVerification = "id_verification"
+        /// Geographic-compliance verification.
+        case geoCompliance = "geo_compliance"
+        /// Payment-method collection.
+        case paymentMethod = "payment_method"
+    }
+}

--- a/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionResponses.swift
+++ b/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionResponses.swift
@@ -1,0 +1,46 @@
+//
+//  OnboardingSessionResponses.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 6/26/26.
+//
+
+import Foundation
+
+/// Response model namespace for Onboarding Session API calls.
+public class OnboardingSessionResponses {
+
+    /// The onboarding session returned by `POST /v1/onboarding_sessions`.
+    public struct OnboardingSession: Codable {
+        /// The unique identifier of the onboarding session.
+        public let id: String?
+        /// The account the session onboards.
+        public let accountId: String?
+        /// The onboarding-session token (`onb_sess_…`) passed to ``OnboardingContainerView`` as its `clientSecret`.
+        public let clientSecret: String?
+        /// Where the account holder is redirected after completion, if provided.
+        public let returnUrl: String?
+        /// The ordered onboarding steps for the session.
+        public let steps: [String]?
+        /// The object type. Always `"onboarding_session"`.
+        public let object: String?
+        /// The Unix timestamp at which the session token expires.
+        public let expiresAt: Int?
+        /// `true` for live-mode sessions, `false` in sandbox.
+        public let livemode: Bool?
+        /// The hosted redirect URL for the account holder.
+        public let url: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case accountId = "account_id"
+            case clientSecret = "client_secret"
+            case returnUrl = "return_url"
+            case steps
+            case object
+            case expiresAt = "expires_at"
+            case livemode
+            case url
+        }
+    }
+}

--- a/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionsAPI.swift
+++ b/Sources/Frame/Networking/OnboardingSessions/OnboardingSessionsAPI.swift
@@ -1,0 +1,67 @@
+//
+//  OnboardingSessionsAPI.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 6/26/26.
+//
+
+import Foundation
+
+/// Internal protocol defining the onboarding-sessions API surface, used for mock testing.
+protocol OnboardingSessionsProtocol {
+    // async/await
+    static func createOnboardingSession(request: OnboardingSessionRequest.CreateOnboardingSessionRequest) async throws -> (OnboardingSessionResponses.OnboardingSession?, NetworkingError?)
+
+    // completionHandler
+    static func createOnboardingSession(request: OnboardingSessionRequest.CreateOnboardingSessionRequest, completionHandler: @escaping @Sendable (OnboardingSessionResponses.OnboardingSession?, NetworkingError?) -> Void)
+}
+
+/// Creates onboarding sessions in the Frame SDK.
+///
+/// - Warning: Creating an onboarding session is a **server-only** operation. It authenticates with
+///   your secret key (`sk_`), which must never ship inside an app binary. This API is provided so
+///   the example app can mint a session token for end-to-end testing — it is **not** the intended
+///   production path. Production integrations mint the `onb_sess_…` token from their backend
+///   (`POST /v1/onboarding_sessions`) and hand it to ``OnboardingContainerView`` as its `clientSecret`.
+public class OnboardingSessionsAPI: OnboardingSessionsProtocol, @unchecked Sendable {
+
+    //MARK: Methods using async/await
+
+    /// Creates an onboarding session and returns its `onb_sess_…` client secret.
+    ///
+    /// - Parameter request: The request body specifying the account and onboarding steps.
+    /// - Returns: A tuple containing the decoded onboarding session and any networking error encountered.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
+    public static func createOnboardingSession(request: OnboardingSessionRequest.CreateOnboardingSessionRequest) async throws -> (OnboardingSessionResponses.OnboardingSession?, NetworkingError?) {
+        let endpoint = OnboardingSessionEndpoints.createOnboardingSession
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(OnboardingSessionResponses.OnboardingSession.self, from: data) {
+            return (decodedResponse, error)
+        } else {
+            return (nil, error)
+        }
+    }
+
+    //MARK: Methods using completion handler
+
+    /// Completion-handler variant of `createOnboardingSession(request:)`.
+    ///
+    /// - Parameters:
+    ///   - request: The request body specifying the account and onboarding steps.
+    ///   - completionHandler: Called with the decoded onboarding session and any networking error encountered.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
+    public static func createOnboardingSession(request: OnboardingSessionRequest.CreateOnboardingSessionRequest, completionHandler: @escaping @Sendable (OnboardingSessionResponses.OnboardingSession?, NetworkingError?) -> Void) {
+        let endpoint = OnboardingSessionEndpoints.createOnboardingSession
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+            if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(OnboardingSessionResponses.OnboardingSession.self, from: data) {
+                completionHandler(decodedResponse, error)
+            } else {
+                completionHandler(nil, error)
+            }
+        }
+    }
+}

--- a/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/ApplePayAPI.swift
@@ -44,7 +44,7 @@ public class ApplePayAPI {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, usePublishableKey: true)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decoded, error)
         }
@@ -66,7 +66,7 @@ public class ApplePayAPI {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, usePublishableKey: true)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decoded, error)
         }

--- a/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
@@ -118,7 +118,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !accountId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithAccount(accountId: accountId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             if !forTesting {
                 // Redundancy incase no Customer API calls are ever made.
@@ -158,7 +158,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(encryptedRequest)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -174,7 +174,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -354,7 +354,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func getPaymentMethodsWithAccount(accountId: String, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithAccount(accountId: accountId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: accountId, email: "")
                 completionHandler(decodedResponse, error)
@@ -396,7 +396,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
 
                 let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(encryptedRequest)
 
-                let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+                let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
                 if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                     completionHandler(decodedResponse, error)
                 } else {
@@ -417,7 +417,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
         let endpoint = PaymentMethodEndpoints.createPaymentMethod
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
@@ -56,10 +56,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve, or `nil` for the default first page.
     ///   - perPage: The number of results per page, or `nil` to use the API default.
     /// - Returns: A tuple containing the decoded list response and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethods(page: Int? = nil, perPage: Int? = nil) async throws -> (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethods(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -71,11 +72,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///
     /// - Parameter paymentMethodId: The unique identifier of the payment method to fetch.
     /// - Returns: A tuple containing the decoded ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: retrieve payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodWith(paymentMethodId: String) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.getPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -89,11 +91,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///   - customerId: The unique identifier of the customer.
     ///   - forTesting: Pass `true` to suppress Sift fraud-signal collection during tests.
     /// - Returns: A tuple containing the decoded list response and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsWithCustomer(customerId: String, forTesting: Bool = false) async throws -> (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) {
       guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             if !forTesting {
                 // Redundancy incase no Customer API calls are ever made.
@@ -204,12 +207,13 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///   - paymentMethodId: The unique identifier of the payment method to attach.
     ///   - request: The ``PaymentMethodRequest/AttachPaymentMethodRequest`` specifying the target customer or account.
     /// - Returns: A tuple containing the updated ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: attach payment methods from your backend with sk_, not from the app.")
     public static func attachPaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequest.AttachPaymentMethodRequest) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
     guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.attachPaymentMethodWith(paymentMethodId: paymentMethodId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -221,11 +225,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///
     /// - Parameter paymentMethodId: The unique identifier of the payment method to detach.
     /// - Returns: A tuple containing the detached ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: detach payment methods from your backend with sk_, not from the app.")
     public static func detachPaymentMethodWith(paymentMethodId: String) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.detachPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -237,11 +242,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///
     /// - Parameter paymentMethodId: The unique identifier of the payment method to block.
     /// - Returns: A tuple containing the blocked ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: block payment methods from your backend with sk_, not from the app.")
     public static func blockPaymentMethodWith(paymentMethodId: String) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.blockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -253,11 +259,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///
     /// - Parameter paymentMethodId: The unique identifier of the payment method to unblock.
     /// - Returns: A tuple containing the unblocked ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: unblock payment methods from your backend with sk_, not from the app.")
     public static func unblockPaymentMethodWith(paymentMethodId: String) async throws -> (FrameObjects.PaymentMethod?, NetworkingError?) {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.unblockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -289,10 +296,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve, or `nil` for the default first page.
     ///   - perPage: The number of results per page, or `nil` to use the API default.
     ///   - completionHandler: Called with the decoded list response and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethods(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethods(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -306,10 +314,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - paymentMethodId: The unique identifier of the payment method to fetch.
     ///   - completionHandler: Called with the decoded ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: retrieve payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -323,10 +332,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - customerId: The unique identifier of the customer.
     ///   - completionHandler: Called with the decoded list response and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: list payment methods from your backend with sk_, not from the app.")
     public static func getPaymentMethodsWithCustomer(customerId: String, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: customerId, email: "")
                 completionHandler(decodedResponse, error)
@@ -441,11 +451,12 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     ///   - paymentMethodId: The unique identifier of the payment method to attach.
     ///   - request: The ``PaymentMethodRequest/AttachPaymentMethodRequest`` specifying the target customer or account.
     ///   - completionHandler: Called with the updated ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: attach payment methods from your backend with sk_, not from the app.")
     public static func attachPaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequest.AttachPaymentMethodRequest, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.attachPaymentMethodWith(paymentMethodId: paymentMethodId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -459,10 +470,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - paymentMethodId: The unique identifier of the payment method to detach.
     ///   - completionHandler: Called with the detached ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: detach payment methods from your backend with sk_, not from the app.")
     public static func detachPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.detachPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -476,10 +488,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - paymentMethodId: The unique identifier of the payment method to block.
     ///   - completionHandler: Called with the blocked ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: block payment methods from your backend with sk_, not from the app.")
     public static func blockPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.blockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -493,10 +506,11 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - paymentMethodId: The unique identifier of the payment method to unblock.
     ///   - completionHandler: Called with the unblocked ``FrameObjects/PaymentMethod`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only: unblock payment methods from your backend with sk_, not from the app.")
     public static func unblockPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.unblockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
+++ b/Sources/Frame/Networking/PaymentMethods/PaymentMethodsAPI.swift
@@ -60,7 +60,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func getPaymentMethods(page: Int? = nil, perPage: Int? = nil) async throws -> (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethods(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -77,7 +77,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.getPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -96,7 +96,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !customerId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithCustomer(customerId: customerId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
             if !forTesting {
                 // Redundancy incase no Customer API calls are ever made.
@@ -213,7 +213,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
         let endpoint = PaymentMethodEndpoints.attachPaymentMethodWith(paymentMethodId: paymentMethodId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -230,7 +230,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.detachPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -247,7 +247,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.blockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -264,7 +264,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
       guard !paymentMethodId.isEmpty else { return (nil, nil) }
         let endpoint = PaymentMethodEndpoints.unblockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -300,7 +300,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func getPaymentMethods(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethods(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -318,7 +318,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func getPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -336,7 +336,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func getPaymentMethodsWithCustomer(customerId: String, completionHandler: @escaping @Sendable (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.getPaymentMethodsWithCustomer(customerId: customerId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(PaymentMethodResponses.ListPaymentMethodsResponse.self, from: data) {
                 SiftManager.collectLoginEvent(customerId: customerId, email: "")
                 completionHandler(decodedResponse, error)
@@ -456,7 +456,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
         let endpoint = PaymentMethodEndpoints.attachPaymentMethodWith(paymentMethodId: paymentMethodId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -474,7 +474,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func detachPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.detachPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -492,7 +492,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func blockPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.blockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -510,7 +510,7 @@ public class PaymentMethodsAPI: PaymentMethodProtocol, @unchecked Sendable {
     public static func unblockPaymentMethodWith(paymentMethodId: String, completionHandler: @escaping @Sendable (FrameObjects.PaymentMethod?, NetworkingError?) -> Void) {
         let endpoint = PaymentMethodEndpoints.unblockPaymentMethodWith(paymentMethodId: paymentMethodId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.PaymentMethod.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/ProductPhases/ProductPhasesAPI.swift
+++ b/Sources/Frame/Networking/ProductPhases/ProductPhasesAPI.swift
@@ -54,7 +54,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.getAllProductPhases(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -73,7 +73,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.getProductPhaseWith(productId: productId, phaseId: phaseId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -93,7 +93,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.createProductPhase(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -114,7 +114,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.updateProductPhaseWith(productId: productId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -133,7 +133,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "" && phaseId != "" else { return (nil) }
         let endpoint = ProductPhaseEndpoints.deleteProductPhase(productId: productId, phaseId: phaseId)
 
-        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         return error
     }
 
@@ -149,7 +149,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.bulkUpdateProductPhases(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -169,7 +169,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.getAllProductPhases(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -189,7 +189,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.getProductPhaseWith(productId: productId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -210,7 +210,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.createProductPhase(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -232,7 +232,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.updateProductPhaseWith(productId: productId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -252,7 +252,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         guard productId != "", phaseId != "" else { return completionHandler(nil) }
         let endpoint = ProductPhaseEndpoints.deleteProductPhase(productId: productId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             completionHandler(error)
         }
     }
@@ -269,7 +269,7 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
         let endpoint = ProductPhaseEndpoints.bulkUpdateProductPhases(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/ProductPhases/ProductPhasesAPI.swift
+++ b/Sources/Frame/Networking/ProductPhases/ProductPhasesAPI.swift
@@ -49,11 +49,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///
     /// - Parameter productId: The unique identifier of the product whose phases should be listed.
     /// - Returns: A tuple containing the list response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func listAllProductPhases(productId: String) async throws -> (ProductPhasesResponses.ListProductPhasesResponse?, NetworkingError?) {
         guard productId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.getAllProductPhases(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -67,11 +68,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the owning product.
     ///   - phaseId: The unique identifier of the subscription phase.
     /// - Returns: A tuple containing the decoded phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getProductPhase(productId: String, phaseId: String) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard productId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.getProductPhaseWith(productId: productId, phaseId: phaseId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -85,12 +87,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product to which the phase will be added.
     ///   - request: The request body describing the phase to create.
     /// - Returns: A tuple containing the newly created phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createProductPhase(productId: String, request: ProductPhaseRequests.CreateProductPhase) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard productId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.createProductPhase(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -105,12 +108,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - phaseId: The unique identifier of the phase to update.
     ///   - request: The request body containing the fields to update.
     /// - Returns: A tuple containing the updated phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateProductPhase(productId: String, phaseId: String, request: ProductPhaseRequests.UpdateProductPhase) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard productId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.updateProductPhaseWith(productId: productId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -124,11 +128,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the owning product.
     ///   - phaseId: The unique identifier of the phase to delete.
     /// - Returns: Any networking error that occurred, or `nil` on success.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteProductPhase(productId: String, phaseId: String) async throws -> (NetworkingError?) {
         guard productId != "" && phaseId != "" else { return (nil) }
         let endpoint = ProductPhaseEndpoints.deleteProductPhase(productId: productId, phaseId: phaseId)
 
-        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         return error
     }
 
@@ -138,12 +143,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product whose phases should be replaced.
     ///   - request: The request body containing the complete, ordered set of phases.
     /// - Returns: A tuple containing the updated list of phases and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func bulkUpdateProductPhases(productId: String, request: ProductPhaseRequests.BulkUpdateProductPhase) async throws -> (ProductPhasesResponses.ListProductPhasesResponse?, NetworkingError?) {
         guard productId != "" else { return (nil, nil) }
         let endpoint = ProductPhaseEndpoints.bulkUpdateProductPhases(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -158,11 +164,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - productId: The unique identifier of the product whose phases should be listed.
     ///   - completionHandler: Called with the list response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func listAllProductPhases(productId: String, completionHandler: @escaping @Sendable (ProductPhasesResponses.ListProductPhasesResponse?, NetworkingError?) -> Void) {
         guard productId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.getAllProductPhases(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductPhasesResponses.ListProductPhasesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -177,11 +184,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the owning product.
     ///   - phaseId: The unique identifier of the subscription phase.
     ///   - completionHandler: Called with the decoded phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getProductPhase(productId: String, phaseId: String, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard productId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.getProductPhaseWith(productId: productId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -196,12 +204,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product to which the phase will be added.
     ///   - request: The request body describing the phase to create.
     ///   - completionHandler: Called with the newly created phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createProductPhase(productId: String, request: ProductPhaseRequests.CreateProductPhase, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard productId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.createProductPhase(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -217,12 +226,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - phaseId: The unique identifier of the phase to update.
     ///   - request: The request body containing the fields to update.
     ///   - completionHandler: Called with the updated phase and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateProductPhase(productId: String, phaseId: String, request: ProductPhaseRequests.UpdateProductPhase, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard productId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.updateProductPhaseWith(productId: productId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -237,11 +247,12 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the owning product.
     ///   - phaseId: The unique identifier of the phase to delete.
     ///   - completionHandler: Called with any networking error that occurred, or `nil` on success.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteProductPhase(productId: String, phaseId: String, completionHandler: @escaping @Sendable (NetworkingError?) -> Void) {
         guard productId != "", phaseId != "" else { return completionHandler(nil) }
         let endpoint = ProductPhaseEndpoints.deleteProductPhase(productId: productId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             completionHandler(error)
         }
     }
@@ -252,12 +263,13 @@ public class ProductPhasesAPI: ProductPhasesProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product whose phases should be replaced.
     ///   - request: The request body containing the complete, ordered set of phases.
     ///   - completionHandler: Called with the updated product list response and any networking error that occurred.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func bulkUpdateProductPhases(productId: String, request: ProductPhaseRequests.BulkUpdateProductPhase, completionHandler: @escaping @Sendable (ProductResponses.ListProductsResponse?, NetworkingError?) -> Void) {
         guard productId != "" else { return completionHandler(nil, nil) }
         let endpoint = ProductPhaseEndpoints.bulkUpdateProductPhases(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Products/ProductsAPI.swift
+++ b/Sources/Frame/Networking/Products/ProductsAPI.swift
@@ -36,11 +36,12 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The request body containing the product details to create.
     /// - Returns: A tuple containing the newly created ``FrameObjects/Product`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func createProduct(request: ProductRequests.CreateProductRequest) async throws -> (FrameObjects.Product?, NetworkingError?) {
         let endpoint = ProductEndpoints.createProduct
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -54,11 +55,12 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product to update.
     ///   - request: The request body containing the fields to update.
     /// - Returns: A tuple containing the updated ``FrameObjects/Product`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func updateProduct(productId: String, request: ProductRequests.UpdateProductRequest) async throws -> (FrameObjects.Product?, NetworkingError?) {
         let endpoint = ProductEndpoints.updateProduct(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -72,10 +74,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - perPage: The maximum number of products to return per page.
     ///   - page: The page number to retrieve.
     /// - Returns: A tuple containing a ``ProductResponses/ListProductsResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func getProducts(perPage: Int?, page: Int?) async throws -> (ProductResponses.ListProductsResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.getProducts(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -87,10 +90,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///
     /// - Parameter productId: The unique identifier of the product to fetch.
     /// - Returns: A tuple containing the matching ``FrameObjects/Product`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func getProduct(productId: String) async throws -> (FrameObjects.Product?, NetworkingError?) {
         let endpoint = ProductEndpoints.getProduct(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -105,10 +109,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - active: An optional flag to filter by active or inactive products.
     ///   - shippable: An optional flag to filter by whether products are shippable.
     /// - Returns: A tuple containing a ``ProductResponses/SearchProductResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func searchProduct(name: String?, active: Bool?, shippable: Bool?) async throws -> (ProductResponses.SearchProductResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.searchProduct(name: name, active: active, shippable: shippable)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.SearchProductResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -120,10 +125,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///
     /// - Parameter productId: The unique identifier of the product to delete.
     /// - Returns: A tuple containing a ``ProductResponses/DeleteProductResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func deleteProduct(productId: String) async throws -> (ProductResponses.DeleteProductResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.deleteProduct(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.DeleteProductResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -138,11 +144,12 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The request body containing the product details to create.
     ///   - completionHandler: Called with the newly created ``FrameObjects/Product`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func createProduct(request: ProductRequests.CreateProductRequest, completionHandler: @escaping @Sendable (FrameObjects.Product?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.createProduct
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -157,11 +164,12 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - productId: The unique identifier of the product to update.
     ///   - request: The request body containing the fields to update.
     ///   - completionHandler: Called with the updated ``FrameObjects/Product`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func updateProduct(productId: String, request: ProductRequests.UpdateProductRequest, completionHandler: @escaping @Sendable (FrameObjects.Product?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.updateProduct(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -176,10 +184,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - perPage: The maximum number of products to return per page.
     ///   - page: The page number to retrieve.
     ///   - completionHandler: Called with a ``ProductResponses/ListProductsResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func getProducts(perPage: Int?, page: Int?, completionHandler: @escaping @Sendable (ProductResponses.ListProductsResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.getProducts(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -193,10 +202,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - productId: The unique identifier of the product to fetch.
     ///   - completionHandler: Called with the matching ``FrameObjects/Product`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func getProduct(productId: String, completionHandler: @escaping @Sendable (FrameObjects.Product?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.getProduct(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -212,10 +222,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     ///   - active: An optional flag to filter by active or inactive products.
     ///   - shippable: An optional flag to filter by whether products are shippable.
     ///   - completionHandler: Called with a ``ProductResponses/SearchProductResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func searchProduct(name: String?, active: Bool?, shippable: Bool?, completionHandler: @escaping @Sendable (ProductResponses.SearchProductResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.searchProduct(name: name, active: active, shippable: shippable)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.SearchProductResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -229,10 +240,11 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - productId: The unique identifier of the product to delete.
     ///   - completionHandler: Called with a ``ProductResponses/DeleteProductResponse`` or a ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     static func deleteProduct(productId: String, completionHandler: @escaping @Sendable (ProductResponses.DeleteProductResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.deleteProduct(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.DeleteProductResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Products/ProductsAPI.swift
+++ b/Sources/Frame/Networking/Products/ProductsAPI.swift
@@ -41,7 +41,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
         let endpoint = ProductEndpoints.createProduct
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -60,7 +60,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
         let endpoint = ProductEndpoints.updateProduct(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -78,7 +78,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func getProducts(perPage: Int?, page: Int?) async throws -> (ProductResponses.ListProductsResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.getProducts(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -94,7 +94,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func getProduct(productId: String) async throws -> (FrameObjects.Product?, NetworkingError?) {
         let endpoint = ProductEndpoints.getProduct(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -113,7 +113,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func searchProduct(name: String?, active: Bool?, shippable: Bool?) async throws -> (ProductResponses.SearchProductResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.searchProduct(name: name, active: active, shippable: shippable)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.SearchProductResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -129,7 +129,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func deleteProduct(productId: String) async throws -> (ProductResponses.DeleteProductResponse?, NetworkingError?) {
         let endpoint = ProductEndpoints.deleteProduct(productId: productId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.DeleteProductResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -149,7 +149,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
         let endpoint = ProductEndpoints.createProduct
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -169,7 +169,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
         let endpoint = ProductEndpoints.updateProduct(productId: productId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -188,7 +188,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func getProducts(perPage: Int?, page: Int?, completionHandler: @escaping @Sendable (ProductResponses.ListProductsResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.getProducts(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.ListProductsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -206,7 +206,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func getProduct(productId: String, completionHandler: @escaping @Sendable (FrameObjects.Product?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.getProduct(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Product.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -226,7 +226,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func searchProduct(name: String?, active: Bool?, shippable: Bool?, completionHandler: @escaping @Sendable (ProductResponses.SearchProductResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.searchProduct(name: name, active: active, shippable: shippable)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.SearchProductResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -244,7 +244,7 @@ public class ProductsAPI: ProductsProtocol, @unchecked Sendable {
     static func deleteProduct(productId: String, completionHandler: @escaping @Sendable (ProductResponses.DeleteProductResponse?, NetworkingError?) -> Void) {
         let endpoint = ProductEndpoints.deleteProduct(productId: productId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(ProductResponses.DeleteProductResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Refunds/RefundsAPI.swift
+++ b/Sources/Frame/Networking/Refunds/RefundsAPI.swift
@@ -32,11 +32,12 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The request body containing the refund details.
     /// - Returns: A tuple of the created ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createRefund(request: RefundRequests.CreateRefundRequest) async throws -> (FrameObjects.Refund?, NetworkingError?) {
         let endpoint = RefundEndpoints.createRefund
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -52,10 +53,11 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     ///   - perPage: The number of results to return per page.
     ///   - page: The page number to retrieve.
     /// - Returns: A tuple of a ``RefundResponses/ListRefundsResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getRefunds(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int? = nil, page: Int? = nil) async throws -> (RefundResponses.ListRefundsResponse?, NetworkingError?) {
         let endpoint = RefundEndpoints.getRefunds(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(RefundResponses.ListRefundsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -67,11 +69,12 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     ///
     /// - Parameter refundId: The unique identifier of the refund to retrieve.
     /// - Returns: A tuple of the matching ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getRefundWith(refundId: String) async throws -> (FrameObjects.Refund?, NetworkingError?) {
         guard !refundId.isEmpty else { return (nil, nil) }
         let endpoint = RefundEndpoints.getRefundWith(refundId: refundId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -83,11 +86,12 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     ///
     /// - Parameter refundId: The unique identifier of the refund to cancel.
     /// - Returns: A tuple of the updated ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func cancelRefund(refundId: String) async throws -> (FrameObjects.Refund?, NetworkingError?) {
         guard !refundId.isEmpty else { return (nil, nil) }
         let endpoint = RefundEndpoints.cancelRefund(refundId: refundId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -102,11 +106,12 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The request body containing the refund details.
     ///   - completionHandler: Called with the created ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createRefund(request: RefundRequests.CreateRefundRequest, completionHandler: @escaping @Sendable (FrameObjects.Refund?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.createRefund
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -123,10 +128,11 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     ///   - perPage: The number of results to return per page.
     ///   - page: The page number to retrieve.
     ///   - completionHandler: Called with a ``RefundResponses/ListRefundsResponse`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getRefunds(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int? = nil, page: Int? = nil, completionHandler: @escaping @Sendable (RefundResponses.ListRefundsResponse?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.getRefunds(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(RefundResponses.ListRefundsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -140,10 +146,11 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - refundId: The unique identifier of the refund to retrieve.
     ///   - completionHandler: Called with the matching ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getRefundWith(refundId: String, completionHandler: @escaping @Sendable (FrameObjects.Refund?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.getRefundWith(refundId: refundId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -157,10 +164,11 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - refundId: The unique identifier of the refund to cancel.
     ///   - completionHandler: Called with the updated ``FrameObjects/Refund`` and an optional ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func cancelRefund(refundId: String, completionHandler: @escaping @Sendable (FrameObjects.Refund?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.cancelRefund(refundId: refundId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Refunds/RefundsAPI.swift
+++ b/Sources/Frame/Networking/Refunds/RefundsAPI.swift
@@ -37,7 +37,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
         let endpoint = RefundEndpoints.createRefund
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -57,7 +57,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     public static func getRefunds(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int? = nil, page: Int? = nil) async throws -> (RefundResponses.ListRefundsResponse?, NetworkingError?) {
         let endpoint = RefundEndpoints.getRefunds(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(RefundResponses.ListRefundsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -74,7 +74,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
         guard !refundId.isEmpty else { return (nil, nil) }
         let endpoint = RefundEndpoints.getRefundWith(refundId: refundId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -91,7 +91,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
         guard !refundId.isEmpty else { return (nil, nil) }
         let endpoint = RefundEndpoints.cancelRefund(refundId: refundId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -111,7 +111,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
         let endpoint = RefundEndpoints.createRefund
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -132,7 +132,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     public static func getRefunds(chargeId: String? = nil, chargeIntentId: String? = nil, perPage: Int? = nil, page: Int? = nil, completionHandler: @escaping @Sendable (RefundResponses.ListRefundsResponse?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.getRefunds(chargeId: chargeId, chargeIntentId: chargeIntentId, perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(RefundResponses.ListRefundsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -150,7 +150,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     public static func getRefundWith(refundId: String, completionHandler: @escaping @Sendable (FrameObjects.Refund?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.getRefundWith(refundId: refundId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -168,7 +168,7 @@ public class RefundsAPI: RefundsProtocol, @unchecked Sendable {
     public static func cancelRefund(refundId: String, completionHandler: @escaping @Sendable (FrameObjects.Refund?, NetworkingError?) -> Void) {
         let endpoint = RefundEndpoints.cancelRefund(refundId: refundId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Refund.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/SonarSessionManager.swift
+++ b/Sources/Frame/Networking/SonarSessionManager.swift
@@ -32,7 +32,7 @@ public final class SessionManager {
         do {
             let endpoint = SonarSessionEndpoints.create
             let body = try FrameNetworking.shared.jsonEncoder.encode(SessionRequestBody(fingerprintVisitorId: visitorId))
-            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body)
+            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body, auth: .publishable)
             
             if let error {
                 throw error
@@ -58,7 +58,7 @@ public final class SessionManager {
         do {
             let endpoint = SonarSessionEndpoints.update(id: current)
             let body = try FrameNetworking.shared.jsonEncoder.encode(SessionRequestBody(fingerprintVisitorId: visitorId))
-            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body)
+            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body, auth: .publishable)
             
             if let error {
                 throw error

--- a/Sources/Frame/Networking/SubscriptionPhases/SubscriptionPhasesAPI.swift
+++ b/Sources/Frame/Networking/SubscriptionPhases/SubscriptionPhasesAPI.swift
@@ -114,7 +114,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getAllSubscriptionPhases(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -132,7 +132,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -151,7 +151,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.createSubscriptionPhase(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -171,7 +171,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.updateSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -189,7 +189,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "" && phaseId != "" else { return (nil) }
         let endpoint = SubscriptionPhaseEndpoints.deleteSubscriptionPhase(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         return error
     }
 
@@ -204,7 +204,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.bulkUpdateSubscriptionPhases(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -223,7 +223,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getAllSubscriptionPhases(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -242,7 +242,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -262,7 +262,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.createSubscriptionPhase(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -283,7 +283,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.updateSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -302,7 +302,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         guard subscriptionId != "", phaseId != "" else { return completionHandler(nil) }
         let endpoint = SubscriptionPhaseEndpoints.deleteSubscriptionPhase(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             completionHandler(error)
         }
     }
@@ -318,7 +318,7 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
         let endpoint = SubscriptionPhaseEndpoints.bulkUpdateSubscriptionPhases(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/SubscriptionPhases/SubscriptionPhasesAPI.swift
+++ b/Sources/Frame/Networking/SubscriptionPhases/SubscriptionPhasesAPI.swift
@@ -109,11 +109,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     /// Lists all phases for the given subscription.
     /// - Parameter subscriptionId: The unique identifier of the parent subscription.
     /// - Returns: A paginated list of subscription phases and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func listAllSubscriptionPhases(subscriptionId: String) async throws -> (SubscriptionPhasesResponses.ListSubscriptionPhasesResponse?, NetworkingError?) {
         guard subscriptionId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getAllSubscriptionPhases(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -126,11 +127,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - phaseId: The unique identifier of the phase to retrieve.
     /// - Returns: The requested ``FrameObjects/SubscriptionPhase`` and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscriptionPhase(subscriptionId: String, phaseId: String) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard subscriptionId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -143,12 +145,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - request: The creation parameters.
     /// - Returns: The newly created ``FrameObjects/SubscriptionPhase`` and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createSubscriptionPhase(subscriptionId: String, request: SubscriptionPhaseRequests.CreateSubscriptionPhase) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard subscriptionId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.createSubscriptionPhase(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -162,12 +165,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - phaseId: The unique identifier of the phase to update.
     ///   - request: The update parameters.
     /// - Returns: The updated ``FrameObjects/SubscriptionPhase`` and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateSubscriptionPhase(subscriptionId: String, phaseId: String, request: SubscriptionPhaseRequests.UpdateSubscriptionPhase) async throws -> (FrameObjects.SubscriptionPhase?, NetworkingError?) {
         guard subscriptionId != "" && phaseId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.updateSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -180,11 +184,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - phaseId: The unique identifier of the phase to delete.
     /// - Returns: An optional networking error if the deletion failed.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteSubscriptionPhase(subscriptionId: String, phaseId: String) async throws -> (NetworkingError?) {
         guard subscriptionId != "" && phaseId != "" else { return (nil) }
         let endpoint = SubscriptionPhaseEndpoints.deleteSubscriptionPhase(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (_, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         return error
     }
 
@@ -193,12 +198,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - request: The bulk-update parameters.
     /// - Returns: The updated list of phases and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func bulkUpdateSubscriptionPhases(subscriptionId: String, request: SubscriptionPhaseRequests.BulkUpdateScriptionPhase) async throws -> (SubscriptionPhasesResponses.ListSubscriptionPhasesResponse?, NetworkingError?) {
         guard subscriptionId != "" else { return (nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.bulkUpdateSubscriptionPhases(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -212,11 +218,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     /// - Parameters:
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - completionHandler: Called with the paginated list response and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func listAllSubscriptionPhases(subscriptionId: String, completionHandler: @escaping @Sendable (SubscriptionPhasesResponses.ListSubscriptionPhasesResponse?, NetworkingError?) -> Void) {
         guard subscriptionId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getAllSubscriptionPhases(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionPhasesResponses.ListSubscriptionPhasesResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -230,11 +237,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - phaseId: The unique identifier of the phase to fetch.
     ///   - completionHandler: Called with the matching phase and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscriptionPhase(subscriptionId: String, phaseId: String, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard subscriptionId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.getSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -248,12 +256,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - request: The creation parameters.
     ///   - completionHandler: Called with the newly created phase and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createSubscriptionPhase(subscriptionId: String, request: SubscriptionPhaseRequests.CreateSubscriptionPhase, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard subscriptionId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.createSubscriptionPhase(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -268,12 +277,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - phaseId: The unique identifier of the phase to update.
     ///   - request: The update parameters.
     ///   - completionHandler: Called with the updated phase and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateSubscriptionPhase(subscriptionId: String, phaseId: String, request: SubscriptionPhaseRequests.UpdateSubscriptionPhase, completionHandler: @escaping @Sendable (FrameObjects.SubscriptionPhase?, NetworkingError?) -> Void) {
         guard subscriptionId != "", phaseId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.updateSubscriptionPhaseWith(subscriptionId: subscriptionId, phaseId: phaseId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.SubscriptionPhase.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -287,11 +297,12 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - phaseId: The unique identifier of the phase to delete.
     ///   - completionHandler: Called with an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func deleteSubscriptionPhase(subscriptionId: String, phaseId: String, completionHandler: @escaping @Sendable (NetworkingError?) -> Void) {
         guard subscriptionId != "", phaseId != "" else { return completionHandler(nil) }
         let endpoint = SubscriptionPhaseEndpoints.deleteSubscriptionPhase(subscriptionId: subscriptionId, phaseId: phaseId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             completionHandler(error)
         }
     }
@@ -301,12 +312,13 @@ public class SubscriptionPhasesAPI: SubscriptionPhasesProtocol, @unchecked Senda
     ///   - subscriptionId: The unique identifier of the parent subscription.
     ///   - request: The bulk-update parameters.
     ///   - completionHandler: Called with the updated subscriptions list response and an optional networking error.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func bulkUpdateSubscriptionPhases(subscriptionId: String, request: SubscriptionPhaseRequests.BulkUpdateScriptionPhase, completionHandler: @escaping @Sendable (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) -> Void) {
         guard subscriptionId != "" else { return completionHandler(nil, nil) }
         let endpoint = SubscriptionPhaseEndpoints.bulkUpdateSubscriptionPhases(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Subscriptions/SubscriptionsAPI.swift
+++ b/Sources/Frame/Networking/Subscriptions/SubscriptionsAPI.swift
@@ -46,7 +46,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.createSubscription
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -66,7 +66,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.updateSubscription(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -84,7 +84,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     public static func getSubscriptions(page: Int? = nil, perPage: Int? = nil) async throws -> (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) {
         let endpoint = SubscriptionEndpoints.getSubscriptions(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -101,7 +101,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         guard !subscriptionId.isEmpty else { return (nil, nil) }
         let endpoint = SubscriptionEndpoints.getSubscription(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -118,7 +118,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.searchSubscriptions
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
             return (decodedResponse.data, error)
         } else {
@@ -135,7 +135,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         guard !subscriptionId.isEmpty else { return (nil, nil) }
         let endpoint = SubscriptionEndpoints.cancelSubscription(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -155,7 +155,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.createSubscription
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -175,7 +175,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.updateSubscription(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -194,7 +194,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     public static func getSubscriptions(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.getSubscriptions(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -212,7 +212,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     public static func getSubscription(subscriptionId: String, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.getSubscription(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -231,7 +231,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
         let endpoint = SubscriptionEndpoints.searchSubscriptions
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse.data, error)
             } else {
@@ -249,7 +249,7 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     public static func cancelSubscription(subscriptionId: String, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.cancelSubscription(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Subscriptions/SubscriptionsAPI.swift
+++ b/Sources/Frame/Networking/Subscriptions/SubscriptionsAPI.swift
@@ -41,11 +41,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The request body containing subscription creation parameters.
     /// - Returns: A tuple of the created ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createSubscription(request: SubscriptionRequest.CreateSubscriptionRequest?) async throws -> (FrameObjects.Subscription?, NetworkingError?) {
         let endpoint = SubscriptionEndpoints.createSubscription
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -59,12 +60,13 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///   - subscriptionId: The unique identifier of the subscription to update.
     ///   - request: The request body containing fields to update.
     /// - Returns: A tuple of the updated ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateSubscription(subscriptionId: String, request: SubscriptionRequest.UpdateSubscriptionRequest?) async throws -> (FrameObjects.Subscription?, NetworkingError?) {
         guard !subscriptionId.isEmpty else { return (nil, nil) }
         let endpoint = SubscriptionEndpoints.updateSubscription(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -78,10 +80,11 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve. Pass `nil` to use the API default.
     ///   - perPage: The number of results per page. Pass `nil` to use the API default.
     /// - Returns: A tuple of the ``SubscriptionResponses/ListSubscriptionsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscriptions(page: Int? = nil, perPage: Int? = nil) async throws -> (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) {
         let endpoint = SubscriptionEndpoints.getSubscriptions(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -93,11 +96,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///
     /// - Parameter subscriptionId: The unique identifier of the subscription.
     /// - Returns: A tuple of the matching ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscription(subscriptionId: String) async throws -> (FrameObjects.Subscription?, NetworkingError?) {
         guard !subscriptionId.isEmpty else { return (nil, nil) }
         let endpoint = SubscriptionEndpoints.getSubscription(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -109,11 +113,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The request body containing search filters.
     /// - Returns: A tuple of matching ``FrameObjects/Subscription`` objects and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func searchSubscription(request: SubscriptionRequest.SearchSubscriptionRequest?) async throws -> ([FrameObjects.Subscription]?, NetworkingError?) {
         let endpoint = SubscriptionEndpoints.searchSubscriptions
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
             return (decodedResponse.data, error)
         } else {
@@ -125,11 +130,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///
     /// - Parameter subscriptionId: The unique identifier of the subscription to cancel.
     /// - Returns: A tuple of the cancelled ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func cancelSubscription(subscriptionId: String) async throws -> (FrameObjects.Subscription?, NetworkingError?) {
         guard !subscriptionId.isEmpty else { return (nil, nil) }
         let endpoint = SubscriptionEndpoints.cancelSubscription(subscriptionId: subscriptionId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -144,11 +150,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The request body containing subscription creation parameters.
     ///   - completionHandler: Called with the created ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func createSubscription(request: SubscriptionRequest.CreateSubscriptionRequest?, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.createSubscription
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -163,11 +170,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///   - subscriptionId: The unique identifier of the subscription to update.
     ///   - request: The request body containing fields to update.
     ///   - completionHandler: Called with the updated ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func updateSubscription(subscriptionId: String, request: SubscriptionRequest.UpdateSubscriptionRequest?, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.updateSubscription(subscriptionId: subscriptionId)
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -182,10 +190,11 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     ///   - page: The page number to retrieve. Pass `nil` to use the API default.
     ///   - perPage: The number of results per page. Pass `nil` to use the API default.
     ///   - completionHandler: Called with the ``SubscriptionResponses/ListSubscriptionsResponse`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscriptions(page: Int? = nil, perPage: Int? = nil, completionHandler: @escaping @Sendable (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.getSubscriptions(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -199,10 +208,11 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - subscriptionId: The unique identifier of the subscription.
     ///   - completionHandler: Called with the matching ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getSubscription(subscriptionId: String, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.getSubscription(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -216,11 +226,12 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The request body containing search filters.
     ///   - completionHandler: Called with matching ``FrameObjects/Subscription`` objects and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func searchSubscription(request: SubscriptionRequest.SearchSubscriptionRequest?, completionHandler: @escaping @Sendable ([FrameObjects.Subscription]?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.searchSubscriptions
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(SubscriptionResponses.ListSubscriptionsResponse.self, from: data) {
                 completionHandler(decodedResponse.data, error)
             } else {
@@ -234,10 +245,11 @@ public class SubscriptionsAPI: SubscriptionsProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - subscriptionId: The unique identifier of the subscription to cancel.
     ///   - completionHandler: Called with the cancelled ``FrameObjects/Subscription`` and any ``NetworkingError``.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func cancelSubscription(subscriptionId: String, completionHandler: @escaping @Sendable (FrameObjects.Subscription?, NetworkingError?) -> Void) {
         let endpoint = SubscriptionEndpoints.cancelSubscription(subscriptionId: subscriptionId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Subscription.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/TermsOfService/TermsOfServiceAPI.swift
+++ b/Sources/Frame/Networking/TermsOfService/TermsOfServiceAPI.swift
@@ -23,7 +23,7 @@ public class TermsOfServiceAPI {
         let endpoint = TermsOfServiceEndpoints.createToken
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode([String: String]())
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.TermsOfServiceTokenResponse.self, from: data) {
             return (decoded, error)
         }
@@ -40,7 +40,7 @@ public class TermsOfServiceAPI {
         let endpoint = TermsOfServiceEndpoints.update
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable)
         if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.TermsOfServiceTokenResponse.self, from: data) {
             return (decoded, error)
         }
@@ -57,7 +57,7 @@ public class TermsOfServiceAPI {
         let endpoint = TermsOfServiceEndpoints.createToken
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode([String: String]())
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, _, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable) { data, _, error in
             if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.TermsOfServiceTokenResponse.self, from: data) {
                 completionHandler(decoded, error)
             } else {
@@ -77,7 +77,7 @@ public class TermsOfServiceAPI {
         let endpoint = TermsOfServiceEndpoints.update
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, _, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .publishable) { data, _, error in
             if let data, let decoded = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.TermsOfServiceTokenResponse.self, from: data) {
                 completionHandler(decoded, error)
             } else {

--- a/Sources/Frame/Networking/Transfers/TransfersAPI.swift
+++ b/Sources/Frame/Networking/Transfers/TransfersAPI.swift
@@ -30,11 +30,12 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     ///
     /// - Parameter request: The transfer creation parameters including amount, account, and optional payment method details.
     /// - Returns: A tuple containing the created ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
+    /// - Important: Money movement is a server-only operation; this authenticates with the secret key.
     public static func createTransfer(request: TransferRequests.CreateTransferRequest) async throws -> (FrameObjects.Transfer?, NetworkingError?) {
         let endpoint = TransferEndpoints.createTransfer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
         // Don't try to decode an error response as a Transfer — performDataTask
         // already mapped non-2xx to .serverError(statusCode:, errorDescription:);
         // attempting decode would overwrite that with .decodingFailed.
@@ -54,11 +55,12 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     ///
     /// - Parameter transferId: The unique identifier of the transfer to fetch.
     /// - Returns: A tuple containing the matching ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getTransferWith(transferId: String) async throws -> (FrameObjects.Transfer?, NetworkingError?) {
         guard !transferId.isEmpty else { return (nil, nil) }
         let endpoint = TransferEndpoints.getTransferWith(transferId: transferId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -72,10 +74,11 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     ///   - perPage: The number of transfers to return per page. Pass `nil` to use the API default.
     ///   - page: The page number to retrieve. Pass `nil` to retrieve the first page.
     /// - Returns: A tuple containing a ``TransferResponses/ListTransfersResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getTransfers(perPage: Int? = nil, page: Int? = nil) async throws -> (TransferResponses.ListTransfersResponse?, NetworkingError?) {
         let endpoint = TransferEndpoints.getTransfers(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(TransferResponses.ListTransfersResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -90,11 +93,12 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - request: The transfer creation parameters including amount, account, and optional payment method details.
     ///   - completionHandler: Called with the created ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
+    /// - Important: Money movement is a server-only operation; this authenticates with the secret key.
     public static func createTransfer(request: TransferRequests.CreateTransferRequest, completionHandler: @escaping @Sendable (FrameObjects.Transfer?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.createTransfer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -108,10 +112,11 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     /// - Parameters:
     ///   - transferId: The unique identifier of the transfer to fetch.
     ///   - completionHandler: Called with the matching ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getTransferWith(transferId: String, completionHandler: @escaping @Sendable (FrameObjects.Transfer?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.getTransferWith(transferId: transferId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -126,10 +131,11 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     ///   - perPage: The number of transfers to return per page. Pass `nil` to use the API default.
     ///   - page: The page number to retrieve. Pass `nil` to retrieve the first page.
     ///   - completionHandler: Called with a ``TransferResponses/ListTransfersResponse`` on success, or a ``NetworkingError`` on failure.
+    @available(*, deprecated, message: "Server-only — call this from your backend with your secret key (sk_), not from the app.")
     public static func getTransfers(perPage: Int? = nil, page: Int? = nil, completionHandler: @escaping @Sendable (TransferResponses.ListTransfersResponse?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.getTransfers(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(TransferResponses.ListTransfersResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/Frame/Networking/Transfers/TransfersAPI.swift
+++ b/Sources/Frame/Networking/Transfers/TransfersAPI.swift
@@ -35,7 +35,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
         let endpoint = TransferEndpoints.createTransfer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         // Don't try to decode an error response as a Transfer — performDataTask
         // already mapped non-2xx to .serverError(statusCode:, errorDescription:);
         // attempting decode would overwrite that with .decodingFailed.
@@ -60,7 +60,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
         guard !transferId.isEmpty else { return (nil, nil) }
         let endpoint = TransferEndpoints.getTransferWith(transferId: transferId)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -78,7 +78,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     public static func getTransfers(perPage: Int? = nil, page: Int? = nil) async throws -> (TransferResponses.ListTransfersResponse?, NetworkingError?) {
         let endpoint = TransferEndpoints.getTransfers(perPage: perPage, page: page)
 
-        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
         if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(TransferResponses.ListTransfersResponse.self, from: data) {
             return (decodedResponse, error)
         } else {
@@ -98,7 +98,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
         let endpoint = TransferEndpoints.createTransfer
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -116,7 +116,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     public static func getTransferWith(transferId: String, completionHandler: @escaping @Sendable (FrameObjects.Transfer?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.getTransferWith(transferId: transferId)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {
@@ -135,7 +135,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     public static func getTransfers(perPage: Int? = nil, page: Int? = nil, completionHandler: @escaping @Sendable (TransferResponses.ListTransfersResponse?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.getTransfers(perPage: perPage, page: page)
 
-        FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret) { data, response, error in
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(TransferResponses.ListTransfersResponse.self, from: data) {
                 completionHandler(decodedResponse, error)
             } else {

--- a/Sources/FrameOnboarding/Views/OnboardingContainerView.swift
+++ b/Sources/FrameOnboarding/Views/OnboardingContainerView.swift
@@ -84,19 +84,28 @@ public struct OnboardingContainerView: View {
     /// Guards against emitting a `.cancelled` result on dismiss when the flow already completed.
     @State private var didFinish: Bool = false
 
+    /// The onboarding-session client secret (`onb_sess_…`) that authenticates the flow, if provided.
+    private let onboardingClientSecret: String?
+
     /// Creates an ``OnboardingContainerView`` configured for the given account and capability set.
     ///
     /// - Parameters:
+    ///   - clientSecret: The onboarding-session token (`onb_sess_…`) minted by your server
+    ///     (`POST /v1/onboarding_sessions`) and handed to your app. While the flow is active every
+    ///     onboarding request authenticates with this token, scoping it to a single account. Pass
+    ///     `nil` only for legacy integrations that still authenticate onboarding with a secret key.
     ///   - accountId: An existing Frame account ID to pre-populate data for, or `nil` to create a new account during onboarding.
     ///   - requiredCapabilities: The set of ``FrameObjects/Capabilities`` the user must satisfy; determines which steps are shown.
     ///   - showIntroScreen: Pass `false` to skip the introductory splash and begin the first step immediately. Defaults to `true`.
     ///   - showCompletionScreen: Pass `false` to omit the ``OnboardingFlow/verificationSubmitted`` confirmation screen. Defaults to `true`.
     ///   - onResult: Closure called with a ``FrameResult`` when the flow finishes or is cancelled.
-    public init(accountId: String? = nil,
+    public init(clientSecret: String? = nil,
+                accountId: String? = nil,
                 requiredCapabilities: [FrameObjects.Capabilities] = [],
                 showIntroScreen: Bool = true,
                 showCompletionScreen: Bool = true,
                 onResult: @escaping (FrameResult) -> Void = { _ in }) {
+        self.onboardingClientSecret = clientSecret
         self.onResult = onResult
         self.showIntroScreen = showIntroScreen
         self.showCompletionScreen = showCompletionScreen
@@ -159,6 +168,11 @@ public struct OnboardingContainerView: View {
         .ignoresSafeArea()
         .keyboardDoneToolbar()
         .onAppear {
+            // Bind every onboarding request to the onboarding-session token (onb_sess_…) for the
+            // lifetime of the flow, so calls authenticate per-account instead of with a secret key.
+            if let onboardingClientSecret {
+                FrameNetworking.shared.beginOnboardingSession(clientSecret: onboardingClientSecret)
+            }
             if !showIntroScreen {
                 self.startedOnboarding = true
             }
@@ -207,6 +221,12 @@ public struct OnboardingContainerView: View {
         }
         .frameToastOverlay()
         .onDisappear {
+            // End the onboarding session so later SDK calls revert to pk_/sk_ authentication.
+            // Only clear it when this view actually began one, so a legacy (clientSecret == nil)
+            // container dismissing doesn't wipe a session another flow may have started.
+            if onboardingClientSecret != nil {
+                FrameNetworking.shared.endOnboardingSession()
+            }
             if !didFinish {
                 didFinish = true
                 onResult(.cancelled)

--- a/Sources/FrameOnboarding/Views/OnboardingContainerView.swift
+++ b/Sources/FrameOnboarding/Views/OnboardingContainerView.swift
@@ -172,6 +172,10 @@ public struct OnboardingContainerView: View {
             // lifetime of the flow, so calls authenticate per-account instead of with a secret key.
             if let onboardingClientSecret {
                 FrameNetworking.shared.beginOnboardingSession(clientSecret: onboardingClientSecret)
+            } else {
+                print("⚠️ Frame: onboarding launched without a clientSecret. Requests will fall back to the "
+                      + "configured pk_/sk_ keys, which are not scoped to a single account. Mint an onboarding-session "
+                      + "token from your backend (POST /v1/onboarding_sessions) and pass it as the clientSecret.")
             }
             if !showIntroScreen {
                 self.startedOnboarding = true

--- a/Tests/Frame-iOSTests/ChargeIntentsAPITests.swift
+++ b/Tests/Frame-iOSTests/ChargeIntentsAPITests.swift
@@ -60,15 +60,15 @@ final class ChargeIntentsAPITests: XCTestCase {
     
     func testConfirmChargeIntent() async  {
         FrameNetworking.shared.asyncURLSession = session
-        let confirmation = try? await ChargeIntentsAPI.confirmChargeIntent(intentId: "").0
+        let confirmation = try? await ChargeIntentsAPI.confirmChargeIntent(intentId: "", clientSecret: "ci_secret_test").0
         XCTAssertNil(confirmation)
-        
-        let confirmationTwo = try? await ChargeIntentsAPI.confirmChargeIntent(intentId: "123").0
+
+        let confirmationTwo = try? await ChargeIntentsAPI.confirmChargeIntent(intentId: "123", clientSecret: "ci_secret_test").0
         XCTAssertNil(confirmationTwo)
-        
+
         do {
             session.data = try JSONEncoder().encode(chargeIntentResponse)
-            let (confirmationThree, _) = try await ChargeIntentsAPI.confirmChargeIntent(intentId: "1234")
+            let (confirmationThree, _) = try await ChargeIntentsAPI.confirmChargeIntent(intentId: "1234", clientSecret: "ci_secret_test")
             XCTAssertNotNil(confirmationThree)
             XCTAssertEqual(confirmationThree?.shipping, chargeIntentResponse.shipping)
         } catch {
@@ -116,15 +116,15 @@ final class ChargeIntentsAPITests: XCTestCase {
     
     func testGetChargeIntent() async  {
         FrameNetworking.shared.asyncURLSession = session
-        let intentOne = try? await ChargeIntentsAPI.getChargeIntent(intentId: "").0
+        let intentOne = try? await ChargeIntentsAPI.getChargeIntent(intentId: "", clientSecret: "ci_secret_test").0
         XCTAssertNil(intentOne)
-        
-        let intentTwo = try? await ChargeIntentsAPI.getChargeIntent(intentId: "123").0
+
+        let intentTwo = try? await ChargeIntentsAPI.getChargeIntent(intentId: "123", clientSecret: "ci_secret_test").0
         XCTAssertNil(intentTwo)
-        
+
         do {
             session.data = try JSONEncoder().encode(chargeIntentResponse)
-            let (intentThree, _) = try await ChargeIntentsAPI.getChargeIntent(intentId: "1234")
+            let (intentThree, _) = try await ChargeIntentsAPI.getChargeIntent(intentId: "1234", clientSecret: "ci_secret_test")
             XCTAssertNotNil(intentThree)
             XCTAssertEqual(intentThree?.shipping, chargeIntentResponse.shipping)
         } catch {

--- a/Tests/Frame-iOSTests/FrameNetworkingTests.swift
+++ b/Tests/Frame-iOSTests/FrameNetworkingTests.swift
@@ -13,8 +13,14 @@ class MockURLProtocol: URLProtocol {
     static var mockData: Data?
     static var mockResponse: URLResponse?
     static var mockError: Error?
+    /// Records the most recent request so tests can inspect the headers the SDK produced
+    /// (e.g. the `Authorization` Bearer token) on the completion-handler / multipart paths.
+    static var lastRequest: URLRequest?
 
-    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canInit(with request: URLRequest) -> Bool {
+        lastRequest = request
+        return true
+    }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {

--- a/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
+++ b/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
@@ -5,7 +5,10 @@
 //  Guard tests for the publishable-key-first auth model (FRA-4313).
 //
 //  These assert that:
-//   - the default credential for a request is the publishable key (pk_), not the secret key;
+//   - client-safe endpoints (tokenization, config, identity, ToS) authenticate with the
+//     publishable key (pk_) — they opt in explicitly via `.publishable`;
+//   - the transport default is `.secret` (most of the API is server-only), so a call with no
+//     explicit `auth:` sends sk_;
 //   - an explicit client secret (charge intent / onboarding session) is sent verbatim;
 //   - while an onboarding session is active, every request carries the onb_sess_ token;
 //   - initializing with an sk_ key does not reject — it warns and continues (non-breaking).
@@ -74,14 +77,16 @@ final class PublishableKeyGuardTests: XCTestCase {
         return session
     }
 
-    /// The default `auth` resolves to the publishable key, never the secret key.
-    func testDefaultAuthUsesPublishableKey() async throws {
+    /// The transport-layer default `auth` resolves to the secret key. Most of the API surface is
+    /// server-only, so the default is `.secret`; client-safe endpoints opt in explicitly with
+    /// `.publishable` (see `testClientSafeAPIUsesPublishableKey`).
+    func testDefaultAuthUsesSecretKey() async throws {
         FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
         let session = makeSession()
 
         _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
 
-        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_456")
     }
 
     /// An explicitly secret-tagged request uses the secret key (the only path that should).
@@ -119,14 +124,15 @@ final class PublishableKeyGuardTests: XCTestCase {
         XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer onb_sess_live_token")
     }
 
-    /// Ending the onboarding session restores publishable-key authentication.
+    /// Ending the onboarding session restores normal credential resolution: a `.publishable`
+    /// request again sends the publishable key instead of the onboarding-session token.
     func testEndingOnboardingSessionRestoresPublishableKey() async throws {
         FrameNetworking.shared.initialize(publishableKey: "pk_test_123")
         let session = makeSession()
         FrameNetworking.shared.beginOnboardingSession(clientSecret: "onb_sess_live_token")
         FrameNetworking.shared.endOnboardingSession()
 
-        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
 
         XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
     }
@@ -167,7 +173,7 @@ final class PublishableKeyGuardTests: XCTestCase {
         let session = makeSession()
 
         // Does not crash/throw; the (misused) key is what gets sent for a publishable request.
-        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
         XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_oops")
     }
 
@@ -199,8 +205,8 @@ final class PublishableKeyGuardTests: XCTestCase {
     }
 
     /// The completion-handler request path (which builds the Authorization header separately from
-    /// the async path) also defaults to the publishable key.
-    func testCompletionHandlerPathDefaultsToPublishableKey() {
+    /// the async path) resolves the same default as the async path: the secret key.
+    func testCompletionHandlerPathDefaultsToSecretKey() {
         FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
         FrameNetworking.shared.endOnboardingSession()
         FrameNetworking.shared.urlSession = makeMockURLSession()
@@ -223,20 +229,21 @@ final class PublishableKeyGuardTests: XCTestCase {
 
         // URLSession can relocate the Authorization header; assert via the captured request if present.
         if let header = MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") {
-            XCTAssertEqual(header, "Bearer pk_test_123")
+            XCTAssertEqual(header, "Bearer sk_test_456")
         }
     }
 
-    /// The multipart upload path resolves auth via the same mechanism: explicit `.secret` sends sk_.
+    /// The multipart upload path resolves auth via the same mechanism: explicit `.publishable`
+    /// sends pk_, and the default (`.secret`) sends sk_.
     func testMultipartUsesResolvedAuth() async throws {
         FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
         let session = makeSession()
         session.data = Data("{}".utf8)
 
-        _ = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: [], auth: .secret)
-        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_456")
+        _ = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: [], auth: .publishable)
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
 
         _ = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: [])
-        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_456")
     }
 }

--- a/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
+++ b/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
@@ -131,6 +131,19 @@ final class PublishableKeyGuardTests: XCTestCase {
         XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
     }
 
+    /// A non-`onb_sess_` token passed to `beginOnboardingSession` still applies (warn-not-break);
+    /// the SDK logs a guardrail warning but uses the value verbatim so behavior is unchanged.
+    func testBeginOnboardingSessionAppliesNonPrefixedTokenVerbatim() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+        FrameNetworking.shared.beginOnboardingSession(clientSecret: "pk_wrong_token")
+        defer { FrameNetworking.shared.endOnboardingSession() }
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_wrong_token")
+    }
+
     /// A representative client-safe API (card tokenization) sends the publishable key.
     func testClientSafeAPIUsesPublishableKey() async throws {
         FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")

--- a/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
+++ b/Tests/Frame-iOSTests/PublishableKeyGuardTests.swift
@@ -1,0 +1,229 @@
+//
+//  PublishableKeyGuardTests.swift
+//  Frame-iOS
+//
+//  Guard tests for the publishable-key-first auth model (FRA-4313).
+//
+//  These assert that:
+//   - the default credential for a request is the publishable key (pk_), not the secret key;
+//   - an explicit client secret (charge intent / onboarding session) is sent verbatim;
+//   - while an onboarding session is active, every request carries the onb_sess_ token;
+//   - initializing with an sk_ key does not reject — it warns and continues (non-breaking).
+//
+
+import XCTest
+@testable import Frame
+
+/// A `URLSessionProtocol` mock that records the most recent request so tests can inspect
+/// the `Authorization` header the SDK produced.
+final class HeaderCapturingAsyncSession: URLSessionProtocol, @unchecked Sendable {
+    private(set) var requests: [URLRequest] = []
+    var data: Data?
+    var response: URLResponse?
+
+    init(data: Data? = Data("{}".utf8),
+         response: URLResponse? = HTTPURLResponse(url: URL(string: "https://api.framepayments.com")!,
+                                                  statusCode: 200, httpVersion: nil, headerFields: nil)) {
+        self.data = data
+        self.response = response
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        guard let data, let response else { throw URLError(.badServerResponse) }
+        return (data, response)
+    }
+
+    var lastRequest: URLRequest? { requests.last }
+
+    /// The `Authorization` header of the most recent request. `initialize()` spawns background
+    /// requests (Evervault config, device attestation); prefer `authorizationHeader(forPath:)`
+    /// when asserting on a specific endpoint to avoid racing those.
+    func authorizationHeader() -> String? {
+        lastRequest?.value(forHTTPHeaderField: "Authorization")
+    }
+
+    /// The `Authorization` header of the most recent request whose URL path contains `path`.
+    func authorizationHeader(forPath path: String) -> String? {
+        requests.last { $0.url?.absoluteString.contains(path) == true }?
+            .value(forHTTPHeaderField: "Authorization")
+    }
+
+    /// Whether any recorded request targeted `path`.
+    func sentRequest(toPath path: String) -> Bool {
+        requests.contains { $0.url?.absoluteString.contains(path) == true }
+    }
+}
+
+final class PublishableKeyGuardTests: XCTestCase {
+
+    private let endpoint = MockFrameEndpoints(endpointURL: "/v1/payment_methods", httpMethod: .POST, queryItems: nil)
+
+    override func tearDown() {
+        // The SDK is a shared singleton; restore a clean auth context so state from these tests
+        // (onboarding session, injected mock session) doesn't bleed into other test classes.
+        FrameNetworking.shared.endOnboardingSession()
+        FrameNetworking.shared.asyncURLSession = URLSession.shared
+        super.tearDown()
+    }
+
+    private func makeSession() -> HeaderCapturingAsyncSession {
+        let session = HeaderCapturingAsyncSession()
+        FrameNetworking.shared.asyncURLSession = session
+        FrameNetworking.shared.endOnboardingSession() // ensure a clean auth context per test
+        return session
+    }
+
+    /// The default `auth` resolves to the publishable key, never the secret key.
+    func testDefaultAuthUsesPublishableKey() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+    }
+
+    /// An explicitly secret-tagged request uses the secret key (the only path that should).
+    func testSecretAuthUsesSecretKey() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_456")
+    }
+
+    /// A per-object client secret (e.g. a charge intent's client_secret) is sent verbatim.
+    func testClientSecretAuthUsesProvidedToken() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123")
+        let session = makeSession()
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .clientSecret("ci_abc_secret_xyz"))
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer ci_abc_secret_xyz")
+    }
+
+    /// While an onboarding session is active, every request — even a `.secret`-tagged one —
+    /// carries the onboarding-session token, scoping the flow to one account.
+    func testOnboardingSessionOverridesAllAuthModes() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+        FrameNetworking.shared.beginOnboardingSession(clientSecret: "onb_sess_live_token")
+        defer { FrameNetworking.shared.endOnboardingSession() }
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .publishable)
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer onb_sess_live_token")
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, auth: .secret)
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer onb_sess_live_token")
+    }
+
+    /// Ending the onboarding session restores publishable-key authentication.
+    func testEndingOnboardingSessionRestoresPublishableKey() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123")
+        let session = makeSession()
+        FrameNetworking.shared.beginOnboardingSession(clientSecret: "onb_sess_live_token")
+        FrameNetworking.shared.endOnboardingSession()
+
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+    }
+
+    /// A representative client-safe API (card tokenization) sends the publishable key.
+    func testClientSafeAPIUsesPublishableKey() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+        // Return a 200 with an empty body; we only care about the Authorization header.
+        session.data = Data("{}".utf8)
+
+        _ = try? await PaymentMethodsAPI.createCardPaymentMethod(
+            request: PaymentMethodRequest.CreateCardPaymentMethodRequest(
+                type: .card, cardNumber: "4242424242424242", expMonth: "12", expYear: "2030", cvc: "123",
+                customer: "cus_1", account: nil, billing: nil),
+            encryptData: false)
+
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+    }
+
+    /// Initializing with an sk_ key as the publishable key does NOT reject (non-breaking);
+    /// the SDK warns and continues, and the value is still usable.
+    func testInitWithSecretKeyDoesNotReject() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "sk_test_oops")
+        let session = makeSession()
+
+        // Does not crash/throw; the (misused) key is what gets sent for a publishable request.
+        _ = try await FrameNetworking.shared.performDataTask(endpoint: endpoint)
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_oops")
+    }
+
+    /// `confirmChargeIntent` sends the provided charge-intent client_secret as the Bearer token,
+    /// not the publishable or secret key.
+    func testConfirmChargeIntentSendsClientSecretAsBearer() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+        session.data = Data("{}".utf8)
+
+        _ = try? await ChargeIntentsAPI.confirmChargeIntent(intentId: "ci_123", clientSecret: "ci_123_secret_abc")
+
+        // Filter by path: initialize() spawns background pk_ requests (Evervault/attestation).
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/charge_intents/ci_123/confirm"),
+                       "Bearer ci_123_secret_abc")
+    }
+
+    /// An empty client_secret short-circuits (no request is made) rather than sending `Bearer `.
+    func testConfirmChargeIntentRejectsEmptyClientSecret() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123")
+        let session = makeSession()
+
+        let (result, error) = try await ChargeIntentsAPI.confirmChargeIntent(intentId: "ci_123", clientSecret: "")
+
+        XCTAssertNil(result)
+        XCTAssertNil(error)
+        XCTAssertFalse(session.sentRequest(toPath: "/v1/charge_intents"),
+                       "no charge-intent request should be sent for an empty client_secret")
+    }
+
+    /// The completion-handler request path (which builds the Authorization header separately from
+    /// the async path) also defaults to the publishable key.
+    func testCompletionHandlerPathDefaultsToPublishableKey() {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        FrameNetworking.shared.endOnboardingSession()
+        FrameNetworking.shared.urlSession = makeMockURLSession()
+        MockURLProtocol.lastRequest = nil
+        MockURLProtocol.mockData = Data("{}".utf8)
+        MockURLProtocol.mockResponse = HTTPURLResponse(url: URL(string: "https://api.framepayments.com")!,
+                                                       statusCode: 200, httpVersion: nil, headerFields: nil)
+        defer {
+            MockURLProtocol.lastRequest = nil
+            MockURLProtocol.mockData = nil
+            MockURLProtocol.mockResponse = nil
+            FrameNetworking.shared.urlSession = URLSession.shared
+        }
+
+        let expectation = expectation(description: "completion handler called")
+        FrameNetworking.shared.performDataTask(endpoint: endpoint) { _, _, _ in
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        // URLSession can relocate the Authorization header; assert via the captured request if present.
+        if let header = MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") {
+            XCTAssertEqual(header, "Bearer pk_test_123")
+        }
+    }
+
+    /// The multipart upload path resolves auth via the same mechanism: explicit `.secret` sends sk_.
+    func testMultipartUsesResolvedAuth() async throws {
+        FrameNetworking.shared.initialize(publishableKey: "pk_test_123", secretKey: "sk_test_456")
+        let session = makeSession()
+        session.data = Data("{}".utf8)
+
+        _ = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: [], auth: .secret)
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer sk_test_456")
+
+        _ = try await FrameNetworking.shared.performMultipartDataTask(endpoint: endpoint, filesToUpload: [])
+        XCTAssertEqual(session.authorizationHeader(forPath: "/v1/payment_methods"), "Bearer pk_test_123")
+    }
+}


### PR DESCRIPTION
### **Summary**
Makes frame-ios publishable-key first. Previously the SDK defaulted to sending the secret key (sk_) on ~95% of endpoints via a per-call usePublishableKey: Bool = false flag — exposing the full merchant API surface from inside the app binary. This PR flips the default to the publishable key (pk_), routes onboarding through the per-account onboarding-session token (onb_sess_), and wires charge-intent confirm/retrieve + 3DS to the server-minted client_secret.

This is a non-breaking change: apiSecretKey is kept (with guidance) so existing checkout / Apple Pay charge flows keep working. Part of the SDK track (parent FRA-4312; audit FRA-4311).

### **What changed**
Auth model. Replaced the usePublishableKey boolean with an explicit FrameAuthMode enum (.publishable / .secret / .clientSecret) threaded through all four FrameNetworking request methods (including multipart, which previously hardcoded the secret key). A single resolver builds the Bearer token, defaulting to .publishable.

### **Init**
New publishable-first initialize(publishableKey:secretKey:…) (secretKey optional); initializeWithAPIKey(_:…) kept as a deprecated shim. Passing sk_, or using .secret on a live request, emits a one-time runtime warning steering integrators to serve the secret key from their backend — but never throws.

### **Charge intent + 3DS.** 
confirmChargeIntent(intentId:clientSecret:) and getChargeIntent(intentId:clientSecret:) send the charge intent's client_secret as the Bearer token (mirrors frame-js). 3DS targets /v1/3ds/intents.

### **Onboarding → onb_sess_.** 
Added a session-scoped token on FrameNetworking (beginOnboardingSession/endOnboardingSession), wired into OnboardingContainerView via a new clientSecret: init param. While active, every onboarding request carries the token, preserving per-account scoping (no bare-pk_ onboarding).

### **Server-only surface.** 
Methods with no in-app consumer (refunds, transfers list/get, customer/account/product/subscription/invoice/dispute CRUD, all index/search/list, charge-intent capture/cancel/void/update) are now @available(*, deprecated) with auth: .secret — source-compatible, compile-time warning only. createTransfer/createChargeIntent stay .secret without deprecation (used by the UI).

### **Tests**
New PublishableKeyGuardTests (11 cases) assert: default → pk_, .secret → sk_, client_secret sent verbatim, onboarding-session override across all auth modes, empty client_secret short-circuits, completion-handler + multipart paths, and that init with sk_ does not reject. Existing charge-intent tests updated for the new signatures.

### **Verification**
All 171 tests pass; Frame, Frame-Onboarding, and the example app build clean on the iOS simulator.
SwiftLint missing_docs clean (every new public symbol documented).