### PR TITLE
SDK: Updated error messaging for Device Attestation

### DIFF
--- a/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
+++ b/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
@@ -28,6 +28,75 @@ public enum DeviceAttestationError: Error {
     case assertionFailed(Error)
 }
 
+extension DeviceAttestationError {
+    /// User-facing message for the toast surface, prefixed with "Error: " to match
+    /// ``NetworkingError/toastMessage(fallback:)``.
+    ///
+    /// Each case maps to a distinct message so a merchant bug report identifies which step of the
+    /// attestation flow failed. For ``challengeFailed(_:)`` and ``attestationRejected(_:)`` the
+    /// associated ``NetworkingError`` may carry a server-supplied message; that is preferred over
+    /// the static text when present.
+    ///
+    /// The underlying `Error` of ``keyGenerationFailed(_:)``, ``attestationFailed(_:)`` and
+    /// ``assertionFailed(_:)`` is deliberately omitted — it is a system error (e.g.
+    /// `Error Domain=com.apple.devicecheck.error Code=2`) written for developers, not shoppers.
+    /// Use ``debugDescription`` to recover it.
+    public func toastMessage() -> String {
+        let body: String
+        switch self {
+        case .notSupported:
+            body = "Apple Pay is not available on this device."
+        case .keyGenerationFailed:
+            body = "Apple Pay could not be set up securely on this device. Please use a card instead."
+        case .challengeFailed(let networkingError):
+            body = Self.serverMessage(from: networkingError)
+                ?? "Apple Pay is temporarily unavailable. Please try again or use a card."
+        case .attestationFailed:
+            body = "Apple Pay could not verify this app. Please use a card instead."
+        case .attestationRejected(let networkingError):
+            body = Self.serverMessage(from: networkingError)
+                ?? "Apple Pay could not verify this device. Please use a card instead."
+        case .noAttestedKey:
+            body = "Apple Pay is not set up on this device yet. Please try again or use a card."
+        case .assertionFailed:
+            body = "Apple Pay could not authorize this payment. Please try again or use a card."
+        }
+        return "Error: \(body)"
+    }
+
+    /// Developer-facing description naming the failed case and including any underlying error.
+    ///
+    /// Intended for logs, `debugMode` output and bug reports — never for a user-visible surface.
+    public var debugDescription: String {
+        switch self {
+        case .notSupported:
+            return "DeviceAttestationError.notSupported: DCAppAttestService.isSupported == false"
+        case .keyGenerationFailed(let error):
+            return "DeviceAttestationError.keyGenerationFailed: \(error)"
+        case .challengeFailed(let networkingError):
+            return "DeviceAttestationError.challengeFailed: \(Self.describe(networkingError))"
+        case .attestationFailed(let error):
+            return "DeviceAttestationError.attestationFailed: \(error)"
+        case .attestationRejected(let networkingError):
+            return "DeviceAttestationError.attestationRejected: \(Self.describe(networkingError))"
+        case .noAttestedKey:
+            return "DeviceAttestationError.noAttestedKey: no attested key in Keychain"
+        case .assertionFailed(let error):
+            return "DeviceAttestationError.assertionFailed: \(error)"
+        }
+    }
+
+    /// The server-supplied message from a `.serverError`, when one is present and parseable.
+    private static func serverMessage(from networkingError: NetworkingError?) -> String? {
+        guard case .serverError(_, let description) = networkingError else { return nil }
+        return NetworkingError.extractEnvelopeMessage(description)
+    }
+
+    private static func describe(_ networkingError: NetworkingError?) -> String {
+        networkingError.map { "\($0)" } ?? "no underlying NetworkingError"
+    }
+}
+
 /// Manages App Attest-based device attestation and per-request assertion generation for the Frame SDK.
 ///
 /// The manager coordinates with Apple's `DCAppAttestService` and the Frame backend to establish

--- a/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
+++ b/Sources/Frame/Networking/DeviceAttestation/DeviceAttestationManager.swift
@@ -108,8 +108,44 @@ public class DeviceAttestationManager: ObservableObject {
     nonisolated(unsafe) public static let shared = DeviceAttestationManager()
 
     private let service = DCAppAttestService.shared
-    private let keychainKey = "com.framepayments.device-attest-key-id"
-    private let pendingKeychainKey = "com.framepayments.device-attest-key-id-pending"
+
+    /// The App Attest environment a key was minted in.
+    ///
+    /// App Attest key IDs are scoped to the environment that created them: a key attested in
+    /// `development` does not exist in `production` and vice versa. Apple exposes no API to query
+    /// the current environment, so it is inferred from the embedded provisioning profile — present
+    /// in development and ad-hoc builds, absent in TestFlight and App Store builds.
+    ///
+    /// This is a heuristic, but a stable one for any given build: the answer cannot change between
+    /// launches of the same binary. A wrong-but-stable answer costs one re-attestation; the
+    /// reset-and-retry in ``generateAssertionForPayment(paymentData:)`` covers the remainder.
+    enum AppAttestEnvironment: String {
+        case development
+        case production
+
+        static var current: AppAttestEnvironment {
+            Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") == nil
+                ? .production
+                : .development
+        }
+    }
+
+    /// Keychain account for the attested key, namespaced by App Attest environment.
+    ///
+    /// Namespacing prevents a key minted by a local development build from being silently reused by
+    /// a TestFlight build of the same app on the same device — the two share a bundle ID, and so
+    /// shared an unscoped Keychain item, which Apple then rejected at assertion time.
+    private var keychainKey: String {
+        "com.framepayments.device-attest-key-id.\(AppAttestEnvironment.current.rawValue)"
+    }
+
+    private var pendingKeychainKey: String {
+        "com.framepayments.device-attest-key-id-pending.\(AppAttestEnvironment.current.rawValue)"
+    }
+
+    /// The pre-namespacing Keychain accounts. Read only to migrate away from; never written.
+    private let legacyKeychainKey = "com.framepayments.device-attest-key-id"
+    private let legacyPendingKeychainKey = "com.framepayments.device-attest-key-id-pending"
 
     // MARK: - Published state
 
@@ -210,6 +246,23 @@ public class DeviceAttestationManager: ObservableObject {
     /// - Throws: ``DeviceAttestationError/noAttestedKey`` if the device has not been attested, or
     ///   ``DeviceAttestationError/assertionFailed(_:)`` if Apple's assertion call fails.
     public func generateAssertionForPayment(paymentData: Data) async throws -> (keyId: String, assertion: String, clientData: String) {
+        do {
+            return try await assertOnce(paymentData: paymentData)
+        } catch let error as DeviceAttestationError {
+            // A stored key that Apple no longer recognises is unrecoverable by retrying with the
+            // same key — the only remedy is to discard it and attest afresh. This rescues a device
+            // wedged by a pre-namespacing key, and covers the case where `AppAttestEnvironment`
+            // guesses wrong. Bounded to a single retry: `assertOnce` is called directly, never
+            // through this method, so the recovery path cannot recurse.
+            guard case .assertionFailed = error else { throw error }
+            resetAttestation()
+            _ = try await attestDevice()
+            return try await assertOnce(paymentData: paymentData)
+        }
+    }
+
+    /// One attempt at generating an assertion with the currently stored key. No recovery.
+    private func assertOnce(paymentData: Data) async throws -> (keyId: String, assertion: String, clientData: String) {
         guard let keyId = attestedKeyId else {
             throw DeviceAttestationError.noAttestedKey
         }
@@ -241,6 +294,10 @@ public class DeviceAttestationManager: ObservableObject {
     public func resetAttestation() {
         deleteKeychainItem(keychainKey)
         deleteKeychainItem(pendingKeychainKey)
+        // Also clear the pre-namespacing items. Namespacing orphans rather than removes them, and
+        // an orphan left behind would still be read by an older SDK version sharing this Keychain.
+        deleteKeychainItem(legacyKeychainKey)
+        deleteKeychainItem(legacyPendingKeychainKey)
         isDeviceAttested = false
     }
 

--- a/Sources/Frame/Views/FrameCheckoutView.swift
+++ b/Sources/Frame/Views/FrameCheckoutView.swift
@@ -161,8 +161,8 @@ public struct FrameCheckoutView: View {
                 let message: String
                 if let networkingError = error as? NetworkingError {
                     message = networkingError.toastMessage()
-                } else if error is DeviceAttestationError {
-                    message = "Error: Apple Pay is not available, there was a device attestation error. Please use a card instead."
+                } else if let attestationError = error as? DeviceAttestationError {
+                    message = attestationError.toastMessage()
                 } else {
                     message = "Error: Apple Pay could not complete. Please try again or use a card."
                 }

--- a/Tests/Frame-iOSTests/DeviceAttestationErrorTests.swift
+++ b/Tests/Frame-iOSTests/DeviceAttestationErrorTests.swift
@@ -1,0 +1,118 @@
+//
+//  DeviceAttestationErrorTests.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 7/10/26.
+//
+
+import XCTest
+@testable import Frame
+
+// MARK: - DeviceAttestationError.toastMessage() tests
+
+final class DeviceAttestationErrorToastMessageTests: XCTestCase {
+
+    /// A sample underlying system error standing in for a DeviceCheck/Secure Enclave failure.
+    private let systemError = NSError(domain: "com.apple.devicecheck.error", code: 2)
+
+    /// One instance of every case, used to assert cross-case properties.
+    private var allCases: [DeviceAttestationError] {
+        [
+            .notSupported,
+            .keyGenerationFailed(systemError),
+            .challengeFailed(nil),
+            .attestationFailed(systemError),
+            .attestationRejected(nil),
+            .noAttestedKey,
+            .assertionFailed(systemError),
+        ]
+    }
+
+    /// The regression this whole change exists to prevent: every case previously collapsed to one
+    /// generic string, so a merchant bug report could not identify which step failed.
+    func testEveryCaseProducesADistinctMessage() {
+        let messages = allCases.map { $0.toastMessage() }
+        XCTAssertEqual(Set(messages).count, allCases.count,
+                       "Two or more DeviceAttestationError cases share a toast message")
+    }
+
+    func testAllMessagesArePrefixedForConsistencyWithNetworkingError() {
+        for error in allCases {
+            XCTAssertTrue(error.toastMessage().hasPrefix("Error: "),
+                          "Missing 'Error: ' prefix: \(error.toastMessage())")
+        }
+    }
+
+    /// The underlying system error is developer-facing and must never reach a payment screen.
+    func testWrappedSystemErrorIsNeverLeakedIntoTheToast() {
+        let wrapping: [DeviceAttestationError] = [
+            .keyGenerationFailed(systemError),
+            .attestationFailed(systemError),
+            .assertionFailed(systemError),
+        ]
+        for error in wrapping {
+            let message = error.toastMessage()
+            XCTAssertFalse(message.contains("devicecheck"), "Leaked system error domain: \(message)")
+            XCTAssertFalse(message.contains("Code=2"), "Leaked system error code: \(message)")
+        }
+    }
+
+    // MARK: Server-supplied messages
+
+    func testChallengeFailedPrefersServerEnvelopeMessage() {
+        let networkingError = NetworkingError.serverError(
+            statusCode: 422,
+            errorDescription: #"{"error_details":{"message":"Challenge expired"}}"#
+        )
+        XCTAssertEqual(DeviceAttestationError.challengeFailed(networkingError).toastMessage(),
+                       "Error: Challenge expired")
+    }
+
+    func testAttestationRejectedPrefersServerEnvelopeMessage() {
+        let networkingError = NetworkingError.serverError(
+            statusCode: 422,
+            errorDescription: #"{"error_details":"Device not attested"}"#
+        )
+        XCTAssertEqual(DeviceAttestationError.attestationRejected(networkingError).toastMessage(),
+                       "Error: Device not attested")
+    }
+
+    /// A nil NetworkingError, a non-server error, and an unparseable body all fall back to the
+    /// static per-case text rather than surfacing an empty or garbled message.
+    func testChallengeFailedFallsBackWhenNoServerMessageIsAvailable() {
+        let fallback = DeviceAttestationError.challengeFailed(nil).toastMessage()
+        XCTAssertEqual(DeviceAttestationError.challengeFailed(.unknownError).toastMessage(), fallback)
+        XCTAssertEqual(
+            DeviceAttestationError.challengeFailed(
+                .serverError(statusCode: 500, errorDescription: "not json")
+            ).toastMessage(),
+            fallback
+        )
+        XCTAssertFalse(fallback.isEmpty)
+    }
+}
+
+// MARK: - DeviceAttestationError.debugDescription tests
+
+final class DeviceAttestationErrorDebugDescriptionTests: XCTestCase {
+
+    private let systemError = NSError(domain: "com.apple.devicecheck.error", code: 2)
+
+    /// debugDescription is the escape hatch that recovers what the toast deliberately hides.
+    func testDebugDescriptionIncludesTheWrappedSystemError() {
+        let description = DeviceAttestationError.attestationFailed(systemError).debugDescription
+        XCTAssertTrue(description.contains("attestationFailed"))
+        XCTAssertTrue(description.contains("com.apple.devicecheck.error"))
+    }
+
+    func testDebugDescriptionNamesTheCaseForErrorsWithoutAPayload() {
+        XCTAssertTrue(DeviceAttestationError.notSupported.debugDescription.contains("notSupported"))
+        XCTAssertTrue(DeviceAttestationError.noAttestedKey.debugDescription.contains("noAttestedKey"))
+    }
+
+    func testDebugDescriptionHandlesAbsentNetworkingError() {
+        let description = DeviceAttestationError.challengeFailed(nil).debugDescription
+        XCTAssertTrue(description.contains("challengeFailed"))
+        XCTAssertTrue(description.contains("no underlying NetworkingError"))
+    }
+}

--- a/Tests/Frame-iOSTests/DeviceAttestationErrorTests.swift
+++ b/Tests/Frame-iOSTests/DeviceAttestationErrorTests.swift
@@ -92,6 +92,37 @@ final class DeviceAttestationErrorToastMessageTests: XCTestCase {
     }
 }
 
+// MARK: - App Attest environment namespacing tests
+
+final class AppAttestEnvironmentTests: XCTestCase {
+
+    typealias Environment = DeviceAttestationManager.AppAttestEnvironment
+
+    /// The regression that wedged the merchant: a development key reused by a TestFlight build.
+    /// The two environments must never resolve to the same Keychain account.
+    func testEnvironmentsProduceDistinctKeychainAccounts() {
+        XCTAssertNotEqual(Environment.development.rawValue, Environment.production.rawValue)
+    }
+
+    /// Detection must be stable across calls — an unstable answer would re-attest on every launch,
+    /// burning Secure Enclave keys and hammering the /attest endpoint.
+    func testCurrentEnvironmentIsStableAcrossCalls() {
+        let first = Environment.current
+        for _ in 0..<10 {
+            XCTAssertEqual(Environment.current, first)
+        }
+    }
+
+    /// The test bundle carries no embedded.mobileprovision, so detection must report production
+    /// rather than crashing or defaulting to development. This pins the fallback direction:
+    /// mislabelling a dev build as production costs one re-attestation, which reset-and-retry
+    /// absorbs; the reverse would let a dev key be trusted in production.
+    func testAbsentProvisioningProfileResolvesToProduction() {
+        XCTAssertNil(Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"))
+        XCTAssertEqual(Environment.current, .production)
+    }
+}
+
 // MARK: - DeviceAttestationError.debugDescription tests
 
 final class DeviceAttestationErrorDebugDescriptionTests: XCTestCase {


### PR DESCRIPTION
https://linear.app/framepayments/issue/FRA-5065/investigate-apple-pay-device-attestation-failure-on-testflight