### PR TITLE
SDK: Support Sonar Session on Transfers (FRA-5157)

### DIFF
--- a/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
+++ b/Sources/Frame/Networking/ChargeIntents/ChargeIntentsAPI.swift
@@ -45,7 +45,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
 
         // Automatically insert client's ip address for charge intent
         var updatedRequest = request
-        updatedRequest.sonarSessionId = FrameNetworking.shared.currentSonarSessionId()
+        updatedRequest.sonarSessionId = FrameNetworking.shared.currentSonarSessionId(accountId: request.account)
         updatedRequest.fraudSignals = ChargeIntentsRequests.FraudSignals(clientIp: SiftManager.getIPAddress())
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)
@@ -188,7 +188,7 @@ public class ChargeIntentsAPI: ChargeIntentsProtocol, @unchecked Sendable {
         let endpoint = ChargeIntentEndpoints.createChargeIntent
 
         var updatedRequest = request
-        updatedRequest.sonarSessionId = FrameNetworking.shared.currentSonarSessionId()
+        updatedRequest.sonarSessionId = FrameNetworking.shared.currentSonarSessionId(accountId: request.account)
         updatedRequest.fraudSignals = ChargeIntentsRequests.FraudSignals(clientIp: SiftManager.getIPAddress())
 
         let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(updatedRequest)

--- a/Sources/Frame/Networking/CommonObjects.swift
+++ b/Sources/Frame/Networking/CommonObjects.swift
@@ -164,11 +164,29 @@ extension NetworkingError {
     public func toastMessage(fallback: String = "Something went wrong. Please try again.") -> String {
         let body: String
         if case .serverError(_, let description) = self {
-            body = Self.extractEnvelopeMessage(description) ?? fallback
+            let message = Self.extractEnvelopeMessage(description)
+            body = message.flatMap(Self.riskMessage(for:)) ?? message ?? fallback
         } else {
             body = fallback
         }
         return "Error: \(body)"
+    }
+
+    /// Human copy for the risk and geo-compliance rejections, which the server reports as bare
+    /// codes (`sonar_session_required`) that would otherwise be shown to shoppers verbatim.
+    ///
+    /// - Returns: The replacement message, or `nil` if `message` is not one of these codes.
+    static func riskMessage(for message: String) -> String? {
+        switch message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "sonar_session_required":
+            return "We couldn't verify this device. Please try again."
+        case "geo_compliance_blocked":
+            return "Payments aren't available in your location."
+        case "geo_compliance_vpn_detected":
+            return "Please turn off your VPN or proxy and try again."
+        default:
+            return nil
+        }
     }
 
     /// Extracts a user-facing message from the Frame error envelope JSON.

--- a/Sources/Frame/Networking/FrameNetworking.swift
+++ b/Sources/Frame/Networking/FrameNetworking.swift
@@ -85,8 +85,12 @@ public class FrameNetworking: ObservableObject {
         }
     }
 
-    func currentSonarSessionId() -> String? {
-        SonarSessionStorage.currentSessionId()
+    /// The Sonar session stored for `accountId`, if any.
+    ///
+    /// Prefer `SessionManager.shared.ensureSession(accountId:)` on a payment path — this only reads
+    /// what is already persisted and will return `nil` if no session has been established yet.
+    func currentSonarSessionId(accountId: String? = nil) -> String? {
+        SonarSessionStorage.currentSessionId(accountId: accountId)
     }
 
     // Async/Await

--- a/Sources/Frame/Networking/SonarSessionManager.swift
+++ b/Sources/Frame/Networking/SonarSessionManager.swift
@@ -1,101 +1,190 @@
 import Foundation
 
+// MARK: - SessionManagerError
+
+/// Failures raised while establishing a Sonar fraud-detection session.
+public enum SessionManagerError: Error, Equatable {
+    /// Fingerprint could not produce a visitor ID, so no session can be created.
+    ///
+    /// Without a visitor ID the server has no device to attach the session to, and any payment
+    /// made against it is rejected by risk checks.
+    case missingVisitorId
+
+    /// The session create or update request failed.
+    case requestFailed(NetworkingError)
+}
+
 // MARK: - SessionManager
 
-/// Manages the lifecycle of a Sonar fraud-detection session, including creation, updating, and local persistence.
+/// Manages the lifecycle of a Sonar fraud-detection session, including creation, refresh, and
+/// local persistence.
 ///
-/// `SessionManager` coordinates with `FingerprintManager` to obtain a device visitor ID and then
-/// creates or refreshes a Sonar session via the Frame networking layer. The resulting session ID is
-/// persisted in `UserDefaults` so that subsequent launches can resume an existing session instead of
-/// creating a new one.
-public final class SessionManager {
-    private let visitorId: String
-    private let storage: SessionStorage = UserDefaultsSessionStorage()
+/// A Sonar session is what lets the server run risk and geo-compliance checks against a payment.
+/// The server resolves a charge's session *through the Frame account*, so a session is only usable
+/// once it has been associated with one — a session created without an account is invisible to
+/// those checks and the payment is rejected with `sonar_session_required`.
+///
+/// Sessions are therefore persisted per account, and are refreshed periodically: the server only
+/// accepts a session whose most recent device event is recent, so a session left untouched for long
+/// enough goes stale and stops backing payments.
+///
+/// Call ``ensureSession(accountId:)`` before taking a payment and await the result; it is idempotent
+/// and coalesces concurrent callers onto a single network round trip.
+public actor SessionManager {
+    /// The shared session manager used by the SDK.
+    public static let shared = SessionManager()
 
-    /// Creates a `SessionManager` bound to the given Fingerprint visitor identifier.
+    /// How long a stored session is trusted before it is refreshed.
     ///
-    /// - Parameter visitorId: The Fingerprint visitor ID used to associate this session with a device.
-    public init(visitorId: String) {
-        self.visitorId = visitorId
-    }
+    /// The server rejects sessions whose latest device event has aged out, so this sits well inside
+    /// that window: refreshing early is cheap, while being even slightly late fails the payment.
+    private static let refreshInterval: TimeInterval = 15 * 60
 
-    /// Creates a new Sonar session if none is stored, or updates the existing session.
-    public func initialize() async {
-        if storage.get() == nil {
-            await createSession()
-        } else {
-            await updateSession()
-        }
-    }
+    /// Cap on how long the SDK waits for Fingerprint to identify the device. A payment must not be
+    /// held up indefinitely by the fingerprinting SDK.
+    private static let visitorIdTimeout: TimeInterval = 5
 
-    private func createSession() async {
-        do {
-            let endpoint = SonarSessionEndpoints.create
-            let body = try FrameNetworking.shared.jsonEncoder.encode(SessionRequestBody(fingerprintVisitorId: visitorId))
-            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body)
-            
-            if let error {
-                throw error
-            }
-            
-            guard let data else {
-                throw NetworkingError.noData
-            }
-            
-            let response = try FrameNetworking.shared.jsonDecoder.decode(SessionResponse.self, from: data)
-            setSession(response.sonarSessionId)
-        } catch {
-            print("Failed to create charge session: \(error)")
-        }
-    }
+    private let storage: SessionStorage
 
-    private func updateSession() async {
-        guard let current = storage.get() else {
-            await createSession()
-            return
-        }
+    /// In-flight work, keyed by account, so concurrent callers (e.g. a double-tapped Pay button)
+    /// share one round trip instead of racing to mint duplicate sessions.
+    private var inFlight: [String: Task<SessionId, Error>] = [:]
 
-        do {
-            let endpoint = SonarSessionEndpoints.update(id: current)
-            let body = try FrameNetworking.shared.jsonEncoder.encode(SessionRequestBody(fingerprintVisitorId: visitorId))
-            let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: body)
-            
-            if let error {
-                throw error
-            }
-            
-            guard let data else {
-                throw NetworkingError.noData
-            }
-            
-            let response = try FrameNetworking.shared.jsonDecoder.decode(SessionResponse.self, from: data)
-            setSession(response.sonarSessionId)
-        } catch {
-            print("Failed to update session, creating new one: \(error)")
-            clearStoredSessionId()
-            await createSession()
-            return
-        }
-    }
-
-    private func setSession(_ sessionId: SessionId) {
-        storage.set(sessionId)
-    }
-    
-    private func clearStoredSessionId() {
-        storage.clear()
-    }
-    
-    /// Convenience method that fetches the Fingerprint visitor ID and initialises a `SessionManager` in one step.
+    /// Creates a session manager backed by the given storage.
     ///
-    /// Call this from your app's startup path to ensure a valid Sonar session exists before processing payments.
+    /// - Parameter storage: Where session identifiers are persisted. Defaults to `UserDefaults`.
+    public init(storage: SessionStorage = UserDefaultsSessionStorage()) {
+        self.storage = storage
+    }
+
+    /// Returns a session for `accountId` that is fresh enough to back a payment, creating or
+    /// refreshing one if necessary.
+    ///
+    /// Awaiting this before a payment guarantees the session exists and is associated with the
+    /// account — otherwise the payment races SDK start-up and can be rejected with
+    /// `sonar_session_required`.
+    ///
+    /// - Parameter accountId: The Frame account the payment belongs to.
+    /// - Returns: The session identifier to send with the payment.
+    /// - Throws: ``SessionManagerError`` if no session could be established.
+    @discardableResult
+    public func ensureSession(accountId: String) async throws -> SessionId {
+        if let existing = storage.get(accountId: accountId), isFresh(accountId: accountId) {
+            return existing
+        }
+
+        if let running = inFlight[accountId] {
+            return try await running.value
+        }
+
+        let task = Task<SessionId, Error> {
+            try await establishSession(accountId: accountId)
+        }
+        inFlight[accountId] = task
+
+        defer { inFlight[accountId] = nil }
+        return try await task.value
+    }
+
+    /// Establishes a session at SDK start-up, before an account is known.
+    ///
+    /// This is a head start, not a guarantee: the server fetches the device event for a new session
+    /// asynchronously, so creating the session early gives that event time to land before checkout.
+    /// The session is adopted by the account on the first ``ensureSession(accountId:)`` call.
+    ///
+    /// Failures are non-fatal and left to ``ensureSession(accountId:)`` to retry and report, so this
+    /// never throws into the SDK's start-up path.
     public static func initializeSession() async {
-        do {
-            guard let visitorId = try await FingerprintManager.getVisitorId() else { return }
-            let manager = SessionManager(visitorId: visitorId)
-            await manager.initialize()
-        } catch {
-            print("Failed to initialize session with Fingerprint visitorId: \(error)")
+        try? await shared.warmUp()
+    }
+
+    /// Creates a pre-account session if none is stored. See ``initializeSession()``.
+    func warmUp() async throws {
+        guard storage.get(accountId: nil) == nil else { return }
+        let session = try await createSession(accountId: nil)
+        store(session, accountId: nil)
+    }
+
+    // MARK: - Private
+
+    private func isFresh(accountId: String?) -> Bool {
+        guard let last = storage.lastRefresh(accountId: accountId) else { return false }
+        return Date().timeIntervalSince(last) < Self.refreshInterval
+    }
+
+    private func store(_ session: SessionId, accountId: String?) {
+        storage.set(session, accountId: accountId)
+        storage.setLastRefresh(Date(), accountId: accountId)
+    }
+
+    /// Produces a fresh, account-associated session, reusing whatever is already stored.
+    ///
+    /// Three cases, in order of preference:
+    /// 1. A session already exists for the account — refresh it so it is inside the server's
+    ///    freshness window again.
+    /// 2. A pre-account session exists — adopt it onto this account and retire the legacy slot, so
+    ///    it can never be adopted a second time by a different account.
+    /// 3. Nothing stored — create one against the account.
+    private func establishSession(accountId: String) async throws -> SessionId {
+        if let existing = storage.get(accountId: accountId) {
+            let refreshed = try await refreshSession(existing, accountId: accountId)
+            store(refreshed, accountId: accountId)
+            return refreshed
         }
+
+        if let legacy = storage.get(accountId: nil) {
+            let adopted = try await refreshSession(legacy, accountId: accountId)
+            store(adopted, accountId: accountId)
+            // Retire the legacy slot: it now belongs to this account, and leaving it readable would
+            // let the next account on this device adopt the same session.
+            storage.clear(accountId: nil)
+            return adopted
+        }
+
+        let created = try await createSession(accountId: accountId)
+        store(created, accountId: accountId)
+        return created
+    }
+
+    private func createSession(accountId: String?) async throws -> SessionId {
+        let body = SessionRequestBody(fingerprintVisitorId: try await visitorId(), accountId: accountId)
+        return try await perform(endpoint: SonarSessionEndpoints.create, body: body)
+    }
+
+    /// Updates an existing session, which both associates it with `accountId` and records a new
+    /// device event server-side — the latter is what returns the session to the server's freshness
+    /// window.
+    ///
+    /// A session the server no longer recognises (expired, or created under different credentials)
+    /// is replaced rather than propagated as an error.
+    private func refreshSession(_ session: SessionId, accountId: String) async throws -> SessionId {
+        let body = SessionRequestBody(fingerprintVisitorId: try await visitorId(), accountId: accountId)
+        do {
+            return try await perform(endpoint: SonarSessionEndpoints.update(id: session), body: body)
+        } catch SessionManagerError.requestFailed {
+            storage.clear(accountId: accountId)
+            return try await createSession(accountId: accountId)
+        }
+    }
+
+    private func perform(endpoint: SonarSessionEndpoints, body: SessionRequestBody) async throws -> SessionId {
+        let encoded = try FrameNetworking.shared.jsonEncoder.encode(body)
+        let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: encoded)
+
+        if let error { throw SessionManagerError.requestFailed(error) }
+        guard let data else { throw SessionManagerError.requestFailed(.noData) }
+
+        do {
+            return try FrameNetworking.shared.jsonDecoder.decode(SessionResponse.self, from: data).sonarSessionId
+        } catch {
+            throw SessionManagerError.requestFailed(.decodingFailed)
+        }
+    }
+
+    private func visitorId() async throws -> String {
+        guard let id = try? await FingerprintManager.getVisitorId(timeout: Self.visitorIdTimeout), !id.isEmpty else {
+            throw SessionManagerError.missingVisitorId
+        }
+        return id
     }
 }

--- a/Sources/Frame/Networking/SonarSessionManager.swift
+++ b/Sources/Frame/Networking/SonarSessionManager.swift
@@ -4,10 +4,7 @@ import Foundation
 
 /// Failures raised while establishing a Sonar fraud-detection session.
 public enum SessionManagerError: Error, Equatable {
-    /// Fingerprint could not produce a visitor ID, so no session can be created.
-    ///
-    /// Without a visitor ID the server has no device to attach the session to, and any payment
-    /// made against it is rejected by risk checks.
+    /// Fingerprint could not identify the device, so no session can be created.
     case missingVisitorId
 
     /// The session create or update request failed.
@@ -19,35 +16,26 @@ public enum SessionManagerError: Error, Equatable {
 /// Manages the lifecycle of a Sonar fraud-detection session, including creation, refresh, and
 /// local persistence.
 ///
-/// A Sonar session is what lets the server run risk and geo-compliance checks against a payment.
-/// The server resolves a charge's session *through the Frame account*, so a session is only usable
-/// once it has been associated with one — a session created without an account is invisible to
-/// those checks and the payment is rejected with `sonar_session_required`.
+/// The server resolves a payment's session *through the Frame account*, so a session only backs a
+/// payment once it has been associated with one; a session created without an account is invisible
+/// to risk checks and the payment is rejected with `sonar_session_required`. Sessions also go stale:
+/// the server requires the session's latest device event to be recent, and only a create or update
+/// call records one.
 ///
-/// Sessions are therefore persisted per account, and are refreshed periodically: the server only
-/// accepts a session whose most recent device event is recent, so a session left untouched for long
-/// enough goes stale and stops backing payments.
-///
-/// Call ``ensureSession(accountId:)`` before taking a payment and await the result; it is idempotent
-/// and coalesces concurrent callers onto a single network round trip.
+/// Call ``ensureSession(accountId:)`` before taking a payment and await the result.
 public actor SessionManager {
     /// The shared session manager used by the SDK.
     public static let shared = SessionManager()
 
-    /// How long a stored session is trusted before it is refreshed.
-    ///
-    /// The server rejects sessions whose latest device event has aged out, so this sits well inside
-    /// that window: refreshing early is cheap, while being even slightly late fails the payment.
+    /// Sits well inside the server's freshness window: refreshing early is cheap, being slightly
+    /// late fails the payment.
     private static let refreshInterval: TimeInterval = 15 * 60
 
-    /// Cap on how long the SDK waits for Fingerprint to identify the device. A payment must not be
-    /// held up indefinitely by the fingerprinting SDK.
+    /// A payment must not be held up indefinitely by the fingerprinting SDK.
     private static let visitorIdTimeout: TimeInterval = 5
 
     private let storage: SessionStorage
 
-    /// In-flight work, keyed by account, so concurrent callers (e.g. a double-tapped Pay button)
-    /// share one round trip instead of racing to mint duplicate sessions.
     private var inFlight: [String: Task<SessionId, Error>] = [:]
 
     /// Creates a session manager backed by the given storage.
@@ -60,9 +48,7 @@ public actor SessionManager {
     /// Returns a session for `accountId` that is fresh enough to back a payment, creating or
     /// refreshing one if necessary.
     ///
-    /// Awaiting this before a payment guarantees the session exists and is associated with the
-    /// account — otherwise the payment races SDK start-up and can be rejected with
-    /// `sonar_session_required`.
+    /// Idempotent, and coalesces concurrent callers onto a single round trip.
     ///
     /// - Parameter accountId: The Frame account the payment belongs to.
     /// - Returns: The session identifier to send with the payment.
@@ -88,12 +74,9 @@ public actor SessionManager {
 
     /// Establishes a session at SDK start-up, before an account is known.
     ///
-    /// This is a head start, not a guarantee: the server fetches the device event for a new session
-    /// asynchronously, so creating the session early gives that event time to land before checkout.
-    /// The session is adopted by the account on the first ``ensureSession(accountId:)`` call.
-    ///
-    /// Failures are non-fatal and left to ``ensureSession(accountId:)`` to retry and report, so this
-    /// never throws into the SDK's start-up path.
+    /// The server fetches a new session's device event asynchronously, so starting early gives that
+    /// event time to land before checkout. ``ensureSession(accountId:)`` then adopts the session onto
+    /// the account, and is left to retry and report any failure here.
     public static func initializeSession() async {
         try? await shared.warmUp()
     }
@@ -117,14 +100,6 @@ public actor SessionManager {
         storage.setLastRefresh(Date(), accountId: accountId)
     }
 
-    /// Produces a fresh, account-associated session, reusing whatever is already stored.
-    ///
-    /// Three cases, in order of preference:
-    /// 1. A session already exists for the account — refresh it so it is inside the server's
-    ///    freshness window again.
-    /// 2. A pre-account session exists — adopt it onto this account and retire the legacy slot, so
-    ///    it can never be adopted a second time by a different account.
-    /// 3. Nothing stored — create one against the account.
     private func establishSession(accountId: String) async throws -> SessionId {
         if let existing = storage.get(accountId: accountId) {
             let refreshed = try await refreshSession(existing, accountId: accountId)
@@ -135,8 +110,8 @@ public actor SessionManager {
         if let legacy = storage.get(accountId: nil) {
             let adopted = try await refreshSession(legacy, accountId: accountId)
             store(adopted, accountId: accountId)
-            // Retire the legacy slot: it now belongs to this account, and leaving it readable would
-            // let the next account on this device adopt the same session.
+            // Leaving the legacy slot readable would let the next account on this device adopt the
+            // same session.
             storage.clear(accountId: nil)
             return adopted
         }
@@ -151,17 +126,14 @@ public actor SessionManager {
         return try await perform(endpoint: SonarSessionEndpoints.create, body: body)
     }
 
-    /// Updates an existing session, which both associates it with `accountId` and records a new
-    /// device event server-side — the latter is what returns the session to the server's freshness
-    /// window.
-    ///
-    /// A session the server no longer recognises (expired, or created under different credentials)
-    /// is replaced rather than propagated as an error.
+    /// Updates an existing session, associating it with `accountId` and recording a new device event
+    /// server-side — the latter is what returns the session to the freshness window.
     private func refreshSession(_ session: SessionId, accountId: String) async throws -> SessionId {
         let body = SessionRequestBody(fingerprintVisitorId: try await visitorId(), accountId: accountId)
         do {
             return try await perform(endpoint: SonarSessionEndpoints.update(id: session), body: body)
         } catch SessionManagerError.requestFailed {
+            // The server no longer recognises this session, so replace it rather than fail the payment.
             storage.clear(accountId: accountId)
             return try await createSession(accountId: accountId)
         }

--- a/Sources/Frame/Networking/SonarSessions/SonarSessionObjects.swift
+++ b/Sources/Frame/Networking/SonarSessions/SonarSessionObjects.swift
@@ -7,14 +7,10 @@
 
 import Foundation
 
-/// A protocol that defines read, write, and clear operations for persisting a ``SessionId``.
+/// A backing store for the Sonar session identifiers held by the Frame SDK.
 ///
-/// Sessions are scoped to a Frame account. Passing `accountId: nil` addresses the legacy,
-/// pre-account slot, which exists so sessions minted before an account was known can be adopted
-/// once the account is.
-///
-/// Conform to this protocol to provide a custom backing store for the active Sonar charge session
-/// identifier used by the Frame SDK.
+/// Sessions are scoped to a Frame account. `accountId: nil` addresses the pre-account slot, holding
+/// a session minted before the account was known so it can be adopted once it is.
 public protocol SessionStorage {
     /// Returns the session persisted for the given account, or `nil` if none is stored.
     func get(accountId: String?) -> SessionId?
@@ -23,29 +19,27 @@ public protocol SessionStorage {
     ///
     /// - Parameters:
     ///   - value: The ``SessionId`` to store.
-    ///   - accountId: The account the session belongs to, or `nil` for the legacy slot.
+    ///   - accountId: The account the session belongs to, or `nil` for the pre-account slot.
     func set(_ value: SessionId, accountId: String?)
 
     /// Removes the persisted session identifier for the given account.
     func clear(accountId: String?)
 
-    /// The time the session for the given account was last created or refreshed on the server,
-    /// or `nil` when unknown.
+    /// When the given account's session was last created or refreshed on the server, or `nil` when
+    /// unknown.
     func lastRefresh(accountId: String?) -> Date?
 
-    /// Records that the session for the given account was refreshed on the server at `date`.
+    /// Records that the given account's session was created or refreshed on the server at `date`.
     func setLastRefresh(_ date: Date, accountId: String?)
 }
 
 /// A ``SessionStorage`` implementation backed by `UserDefaults`.
 ///
-/// Sessions are keyed per account (`frame_sonar_session_id_{accountId}`) so that a session minted
-/// for one account can never be reused by another on the same device. The unscoped legacy key is
-/// retained for sessions created before an account is known; ``UserDefaultsSessionStorage`` only
-/// reads it, and ``SessionManager`` clears it once the session has been adopted by an account.
+/// Keying per account is what stops one account's session being reused by the next account on the
+/// same device.
 public final class UserDefaultsSessionStorage: SessionStorage {
-    /// The unscoped key used before per-account scoping existed. Still read so an in-flight session
-    /// survives an SDK upgrade, but never written for an account-scoped session.
+    /// The unscoped key predating per-account scoping. Still read so a session survives an SDK
+    /// upgrade, but never written for an account-scoped session.
     static let legacyKey = "frame_charge_session_id"
 
     private static let keyPrefix = "frame_sonar_session_id_"

--- a/Sources/Frame/Networking/SonarSessions/SonarSessionObjects.swift
+++ b/Sources/Frame/Networking/SonarSessions/SonarSessionObjects.swift
@@ -9,66 +9,96 @@ import Foundation
 
 /// A protocol that defines read, write, and clear operations for persisting a ``SessionId``.
 ///
+/// Sessions are scoped to a Frame account. Passing `accountId: nil` addresses the legacy,
+/// pre-account slot, which exists so sessions minted before an account was known can be adopted
+/// once the account is.
+///
 /// Conform to this protocol to provide a custom backing store for the active Sonar charge session
 /// identifier used by the Frame SDK.
 public protocol SessionStorage {
-    /// Returns the currently persisted session identifier, or `nil` if none is stored.
-    func get() -> SessionId?
+    /// Returns the session persisted for the given account, or `nil` if none is stored.
+    func get(accountId: String?) -> SessionId?
 
-    /// Persists the given session identifier to the backing store.
+    /// Persists a session identifier for the given account.
     ///
-    /// - Parameter value: The ``SessionId`` to store.
-    func set(_ value: SessionId)
+    /// - Parameters:
+    ///   - value: The ``SessionId`` to store.
+    ///   - accountId: The account the session belongs to, or `nil` for the legacy slot.
+    func set(_ value: SessionId, accountId: String?)
 
-    /// Removes the persisted session identifier from the backing store.
-    func clear()
+    /// Removes the persisted session identifier for the given account.
+    func clear(accountId: String?)
+
+    /// The time the session for the given account was last created or refreshed on the server,
+    /// or `nil` when unknown.
+    func lastRefresh(accountId: String?) -> Date?
+
+    /// Records that the session for the given account was refreshed on the server at `date`.
+    func setLastRefresh(_ date: Date, accountId: String?)
 }
 
 /// A ``SessionStorage`` implementation backed by `UserDefaults`.
 ///
-/// This is the default session storage used by the Frame SDK to persist the active Sonar charge
-/// session identifier across app launches.
+/// Sessions are keyed per account (`frame_sonar_session_id_{accountId}`) so that a session minted
+/// for one account can never be reused by another on the same device. The unscoped legacy key is
+/// retained for sessions created before an account is known; ``UserDefaultsSessionStorage`` only
+/// reads it, and ``SessionManager`` clears it once the session has been adopted by an account.
 public final class UserDefaultsSessionStorage: SessionStorage {
+    /// The unscoped key used before per-account scoping existed. Still read so an in-flight session
+    /// survives an SDK upgrade, but never written for an account-scoped session.
+    static let legacyKey = "frame_charge_session_id"
+
+    private static let keyPrefix = "frame_sonar_session_id_"
+    private static let refreshSuffix = "_refreshed_at"
+
     private let defaults: UserDefaults
-    private let key: String
 
     /// Creates a new `UserDefaultsSessionStorage` instance.
     ///
-    /// - Parameters:
-    ///   - defaults: The `UserDefaults` suite to use for persistence. Defaults to `.standard`.
-    ///   - key: The key under which the session identifier is stored. Defaults to
-    ///     `"frame_charge_session_id"`.
-    public init(defaults: UserDefaults = .standard, key: String = "frame_charge_session_id") {
+    /// - Parameter defaults: The `UserDefaults` suite to use for persistence. Defaults to `.standard`.
+    public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.key = key
     }
 
-    /// Returns the session identifier stored under the configured key, or `nil` if absent.
-    public func get() -> SessionId? {
-        defaults.string(forKey: key)
+    private func key(for accountId: String?) -> String {
+        guard let accountId, !accountId.isEmpty else { return Self.legacyKey }
+        return Self.keyPrefix + accountId
     }
 
-    /// Stores the given session identifier under the configured key.
-    ///
-    /// - Parameter value: The ``SessionId`` to persist.
-    public func set(_ value: SessionId) {
-        defaults.set(value, forKey: key)
+    /// Returns the session identifier stored for the given account, or `nil` if absent.
+    public func get(accountId: String?) -> SessionId? {
+        defaults.string(forKey: key(for: accountId))
     }
 
-    /// Removes the session identifier from `UserDefaults`.
-    public func clear() {
+    /// Stores the given session identifier for the given account.
+    public func set(_ value: SessionId, accountId: String?) {
+        defaults.set(value, forKey: key(for: accountId))
+    }
+
+    /// Removes the session identifier for the given account.
+    public func clear(accountId: String?) {
+        let key = key(for: accountId)
         defaults.removeObject(forKey: key)
+        defaults.removeObject(forKey: key + Self.refreshSuffix)
+    }
+
+    /// Returns when the given account's session was last created or refreshed on the server,
+    /// or `nil` if that is unknown.
+    public func lastRefresh(accountId: String?) -> Date? {
+        defaults.object(forKey: key(for: accountId) + Self.refreshSuffix) as? Date
+    }
+
+    /// Records that the given account's session was created or refreshed on the server at `date`.
+    public func setLastRefresh(_ date: Date, accountId: String?) {
+        defaults.set(date, forKey: key(for: accountId) + Self.refreshSuffix)
     }
 }
 
 /// A convenience class for reading the active Sonar charge session identifier from `UserDefaults`.
-///
-/// Use ``currentSessionId()`` to retrieve the session identifier that was last persisted by the
-/// Frame SDK without needing a full ``SessionStorage`` instance.
 public class SonarSessionStorage {
-    /// Returns the active Sonar charge session identifier stored in `UserDefaults.standard`, or
-    /// `nil` if no session has been persisted.
-    public static func currentSessionId() -> SessionId? {
-        UserDefaults.standard.string(forKey: "frame_charge_session_id")
+    /// Returns the Sonar session identifier stored for `accountId`, or `nil` if none has been
+    /// persisted. Pass `nil` to read the legacy, pre-account session.
+    public static func currentSessionId(accountId: String? = nil) -> SessionId? {
+        UserDefaultsSessionStorage().get(accountId: accountId)
     }
 }

--- a/Sources/Frame/Networking/SonarSessions/SonarSessionRequests.swift
+++ b/Sources/Frame/Networking/SonarSessions/SonarSessionRequests.swift
@@ -27,9 +27,9 @@ public struct SessionRequestBody: Encodable {
 
     /// The Frame account the session belongs to.
     ///
-    /// Required for any session that will back a payment: the server resolves a charge's session
-    /// through the account, so a session created without this is invisible to risk checks and the
-    /// payment is rejected with `sonar_session_required`. Omitted only for pre-account sessions.
+    /// Required for any session that will back a payment: the server resolves a payment's session
+    /// through the account, so one created without this is invisible to risk checks and the payment
+    /// is rejected with `sonar_session_required`.
     let accountId: String?
 
     init(fingerprintVisitorId: String, accountId: String? = nil) {

--- a/Sources/Frame/Networking/SonarSessions/SonarSessionRequests.swift
+++ b/Sources/Frame/Networking/SonarSessions/SonarSessionRequests.swift
@@ -25,7 +25,20 @@ public struct SessionRequestBody: Encodable {
     /// The Fingerprint visitor identifier used to associate the session with a device fingerprint.
     let fingerprintVisitorId: String
 
+    /// The Frame account the session belongs to.
+    ///
+    /// Required for any session that will back a payment: the server resolves a charge's session
+    /// through the account, so a session created without this is invisible to risk checks and the
+    /// payment is rejected with `sonar_session_required`. Omitted only for pre-account sessions.
+    let accountId: String?
+
+    init(fingerprintVisitorId: String, accountId: String? = nil) {
+        self.fingerprintVisitorId = fingerprintVisitorId
+        self.accountId = accountId
+    }
+
     enum CodingKeys: String, CodingKey {
         case fingerprintVisitorId = "fingerprint_visitor_id"
+        case accountId = "account_id"
     }
 }

--- a/Sources/Frame/Networking/Transfers/TransferRequests.swift
+++ b/Sources/Frame/Networking/Transfers/TransferRequests.swift
@@ -34,8 +34,8 @@ public class TransferRequests {
 
         /// The Sonar session backing this transfer's risk checks.
         ///
-        /// Populated by ``TransfersAPI`` and only ever sent on charge-backed transfers: the API
-        /// accepts it alongside a `sourcePaymentMethodId` and rejects it without one.
+        /// Populated by ``TransfersAPI``. Only sent on charge-backed transfers — the API rejects it
+        /// without a `sourcePaymentMethodId`.
         var sonarSessionId: String?
 
         /// Creates a new ``CreateTransferRequest``.

--- a/Sources/Frame/Networking/Transfers/TransferRequests.swift
+++ b/Sources/Frame/Networking/Transfers/TransferRequests.swift
@@ -32,6 +32,12 @@ public class TransferRequests {
         /// Arbitrary key-value metadata to attach to the transfer.
         public let metadata: [String: String]?
 
+        /// The Sonar session backing this transfer's risk checks.
+        ///
+        /// Populated by ``TransfersAPI`` and only ever sent on charge-backed transfers: the API
+        /// accepts it alongside a `sourcePaymentMethodId` and rejects it without one.
+        var sonarSessionId: String?
+
         /// Creates a new ``CreateTransferRequest``.
         ///
         /// - Parameters:
@@ -63,6 +69,7 @@ public class TransferRequests {
             case accountId = "account_id"
             case sourcePaymentMethodId = "source_payment_method_id"
             case destinationPaymentMethodId = "destination_payment_method_id"
+            case sonarSessionId = "sonar_session_id"
         }
     }
 }

--- a/Sources/Frame/Networking/Transfers/TransfersAPI.swift
+++ b/Sources/Frame/Networking/Transfers/TransfersAPI.swift
@@ -25,12 +25,11 @@ protocol TransfersProtocol {
 /// Manages transfer resources in the Frame Payments SDK, providing methods to create and retrieve transfers.
 public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
 
-    /// Attaches the account's Sonar session so the server can run risk and geo-compliance checks
-    /// against the transfer.
+    /// Attaches the account's Sonar session so the server can run its risk checks against the
+    /// transfer.
     ///
-    /// Only charge-backed transfers carry it. A direct transfer (a payout — no source payment
-    /// method) has no charge to score, and the API rejects the field outright on those, so sending
-    /// it there would turn a working payout into a 400.
+    /// Only charge-backed transfers carry it: a payout has no charge to score, and the API rejects
+    /// the field outright on those, so sending it would turn a working payout into a 400.
     private static func withSonarSession(
         _ request: TransferRequests.CreateTransferRequest
     ) -> TransferRequests.CreateTransferRequest {

--- a/Sources/Frame/Networking/Transfers/TransfersAPI.swift
+++ b/Sources/Frame/Networking/Transfers/TransfersAPI.swift
@@ -24,6 +24,23 @@ protocol TransfersProtocol {
 
 /// Manages transfer resources in the Frame Payments SDK, providing methods to create and retrieve transfers.
 public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
+
+    /// Attaches the account's Sonar session so the server can run risk and geo-compliance checks
+    /// against the transfer.
+    ///
+    /// Only charge-backed transfers carry it. A direct transfer (a payout — no source payment
+    /// method) has no charge to score, and the API rejects the field outright on those, so sending
+    /// it there would turn a working payout into a 400.
+    private static func withSonarSession(
+        _ request: TransferRequests.CreateTransferRequest
+    ) -> TransferRequests.CreateTransferRequest {
+        guard request.sourcePaymentMethodId != nil else { return request }
+
+        var updated = request
+        updated.sonarSessionId = FrameNetworking.shared.currentSonarSessionId(accountId: request.accountId)
+        return updated
+    }
+
     //async/await
 
     /// Creates a new transfer using the provided request body.
@@ -32,7 +49,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     /// - Returns: A tuple containing the created ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
     public static func createTransfer(request: TransferRequests.CreateTransferRequest) async throws -> (FrameObjects.Transfer?, NetworkingError?) {
         let endpoint = TransferEndpoints.createTransfer
-        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(withSonarSession(request))
 
         let (data, error) = try await FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody)
         // Don't try to decode an error response as a Transfer — performDataTask
@@ -92,7 +109,7 @@ public class TransfersAPI: TransfersProtocol, @unchecked Sendable {
     ///   - completionHandler: Called with the created ``FrameObjects/Transfer`` on success, or a ``NetworkingError`` on failure.
     public static func createTransfer(request: TransferRequests.CreateTransferRequest, completionHandler: @escaping @Sendable (FrameObjects.Transfer?, NetworkingError?) -> Void) {
         let endpoint = TransferEndpoints.createTransfer
-        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(request)
+        let requestBody = try? FrameNetworking.shared.jsonEncoder.encode(withSonarSession(request))
 
         FrameNetworking.shared.performDataTask(endpoint: endpoint, requestBody: requestBody) { data, response, error in
             if let data, let decodedResponse = try? FrameNetworking.shared.jsonDecoder.decode(FrameObjects.Transfer.self, from: data) {

--- a/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
@@ -218,8 +218,7 @@ extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
                     }
 
                 case .account(let accountId):
-                    // As in the card flow: the server scores this transfer against the account's
-                    // Sonar session, so make sure one exists before charging.
+                    // The server rejects the transfer outright without a live session for this account.
                     try await SessionManager.shared.ensureSession(accountId: accountId)
 
                     let request = TransferRequests.CreateTransferRequest(

--- a/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameApplePayViewModel.swift
@@ -218,6 +218,10 @@ extension FrameApplePayViewModel: PKPaymentAuthorizationControllerDelegate {
                     }
 
                 case .account(let accountId):
+                    // As in the card flow: the server scores this transfer against the account's
+                    // Sonar session, so make sure one exists before charging.
+                    try await SessionManager.shared.ensureSession(accountId: accountId)
+
                     let request = TransferRequests.CreateTransferRequest(
                         amount: amount,
                         accountId: accountId,

--- a/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
@@ -244,6 +244,10 @@ class FrameCheckoutViewModel: ObservableObject {
         }
         guard let paymentMethodId else { return nil }
 
+        // The transfer is only scored once the account has a live Sonar session, so wait for one
+        // rather than racing SDK start-up and having the server reject the payment outright.
+        try await SessionManager.shared.ensureSession(accountId: accountId)
+
         let request = TransferRequests.CreateTransferRequest(
             amount: amount,
             accountId: accountId,

--- a/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
+++ b/Sources/Frame/ViewModels/FrameCheckoutViewModel.swift
@@ -244,8 +244,8 @@ class FrameCheckoutViewModel: ObservableObject {
         }
         guard let paymentMethodId else { return nil }
 
-        // The transfer is only scored once the account has a live Sonar session, so wait for one
-        // rather than racing SDK start-up and having the server reject the payment outright.
+        // The server rejects the transfer outright without a live session for this account, so wait
+        // for one rather than racing SDK start-up.
         try await SessionManager.shared.ensureSession(accountId: accountId)
 
         let request = TransferRequests.CreateTransferRequest(

--- a/Tests/Frame-iOSTests/SonarSessionTests.swift
+++ b/Tests/Frame-iOSTests/SonarSessionTests.swift
@@ -10,9 +10,8 @@ import XCTest
 
 // MARK: - Request encoding
 
-/// The server resolves a payment's Sonar session through the account, so a session created without
-/// an `account_id` is invisible to risk checks and the payment is rejected with
-/// `sonar_session_required`. Omitting the field was the original bug.
+/// Omitting `account_id` was the original bug: the server resolves a payment's session through the
+/// account, so a session without one is invisible to risk checks.
 final class SessionRequestBodyTests: XCTestCase {
 
     private func encode(_ body: SessionRequestBody) throws -> [String: Any] {
@@ -37,8 +36,7 @@ final class SessionRequestBodyTests: XCTestCase {
 
 // MARK: - Per-account storage
 
-/// Sessions are keyed per account so one account's session can never be adopted by the next account
-/// on the same device — the cross-account contamination fixed on the web SDK in FRA-3280.
+/// Guards the cross-account contamination fixed on the web SDK in FRA-3280.
 final class SessionStorageTests: XCTestCase {
 
     private var defaults: UserDefaults!
@@ -65,15 +63,13 @@ final class SessionStorageTests: XCTestCase {
         XCTAssertEqual(storage.get(accountId: "acc_b"), "fps_b")
     }
 
-    /// The A→B regression: account B must never read account A's session.
     func testOneAccountsSessionIsNotVisibleToAnother() {
         storage.set("fps_a", accountId: "acc_a")
 
         XCTAssertNil(storage.get(accountId: "acc_b"))
     }
 
-    /// A session stored for an account must not leak into the pre-account slot, or the next account
-    /// on this device would adopt it.
+    /// Leaking into the pre-account slot would let the next account on this device adopt it.
     func testAccountSessionIsNotWrittenToTheLegacySlot() {
         storage.set("fps_a", accountId: "acc_a")
 
@@ -81,8 +77,6 @@ final class SessionStorageTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: UserDefaultsSessionStorage.legacyKey))
     }
 
-    /// A session created before an account was known lives in the legacy slot, which is what makes
-    /// it adoptable later.
     func testPreAccountSessionUsesTheLegacyKey() {
         storage.set("fps_legacy", accountId: nil)
 
@@ -90,8 +84,7 @@ final class SessionStorageTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: UserDefaultsSessionStorage.legacyKey), "fps_legacy")
     }
 
-    /// A session persisted by an older SDK build must still be readable after upgrade, so an
-    /// in-flight session survives rather than being silently abandoned.
+    /// A session in flight when the SDK is upgraded must survive rather than be abandoned.
     func testSessionWrittenByAnOlderBuildIsStillReadable() {
         defaults.set("fps_from_old_build", forKey: UserDefaultsSessionStorage.legacyKey)
 
@@ -128,8 +121,8 @@ final class SessionStorageTests: XCTestCase {
 
 // MARK: - Transfer encoding
 
-/// The API accepts `sonar_session_id` only on charge-backed transfers and rejects it on payouts, so
-/// the field must never be attached to a transfer that has no source payment method.
+/// The API rejects `sonar_session_id` on payouts, so it must never be attached to a transfer with no
+/// source payment method.
 final class TransferSonarSessionTests: XCTestCase {
 
     private func encode(_ request: TransferRequests.CreateTransferRequest) throws -> [String: Any] {
@@ -146,7 +139,7 @@ final class TransferSonarSessionTests: XCTestCase {
         XCTAssertEqual(try encode(request)["sonar_session_id"] as? String, "fps_1")
     }
 
-    /// Sending the field on a payout would turn a working transfer into a 400.
+    /// Sending it here would turn a working payout into a 400.
     func testPayoutTransferOmitsTheSonarSessionEntirely() throws {
         let request = TransferRequests.CreateTransferRequest(amount: 5000,
                                                              accountId: "acc_1",
@@ -158,8 +151,7 @@ final class TransferSonarSessionTests: XCTestCase {
 
 // MARK: - Error copy
 
-/// The server reports these rejections as bare codes; shown verbatim they read as
-/// "Error: sonar_session_required", which is what merchants reported.
+/// Shown verbatim these read as "Error: sonar_session_required", which is what merchants reported.
 final class RiskErrorMessageTests: XCTestCase {
 
     private func toast(forServerMessage message: String) -> String {
@@ -179,7 +171,6 @@ final class RiskErrorMessageTests: XCTestCase {
         XCTAssertFalse(toast(forServerMessage: "geo_compliance_vpn_detected").contains("geo_compliance"))
     }
 
-    /// Server messages that are already human must be passed through untouched.
     func testUnrecognisedServerMessagesArePassedThrough() {
         XCTAssertEqual(toast(forServerMessage: "Card submitted is not a test card"),
                        "Error: Card submitted is not a test card")

--- a/Tests/Frame-iOSTests/SonarSessionTests.swift
+++ b/Tests/Frame-iOSTests/SonarSessionTests.swift
@@ -1,0 +1,187 @@
+//
+//  SonarSessionTests.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 7/14/26.
+//
+
+import XCTest
+@testable import Frame
+
+// MARK: - Request encoding
+
+/// The server resolves a payment's Sonar session through the account, so a session created without
+/// an `account_id` is invisible to risk checks and the payment is rejected with
+/// `sonar_session_required`. Omitting the field was the original bug.
+final class SessionRequestBodyTests: XCTestCase {
+
+    private func encode(_ body: SessionRequestBody) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(body)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    func testEncodesAccountIdAlongsideVisitorId() throws {
+        let json = try encode(SessionRequestBody(fingerprintVisitorId: "visitor_1", accountId: "acc_1"))
+
+        XCTAssertEqual(json["fingerprint_visitor_id"] as? String, "visitor_1")
+        XCTAssertEqual(json["account_id"] as? String, "acc_1")
+    }
+
+    func testOmitsAccountIdWhenThereIsNoAccountYet() throws {
+        let json = try encode(SessionRequestBody(fingerprintVisitorId: "visitor_1"))
+
+        XCTAssertEqual(json["fingerprint_visitor_id"] as? String, "visitor_1")
+        XCTAssertNil(json["account_id"])
+    }
+}
+
+// MARK: - Per-account storage
+
+/// Sessions are keyed per account so one account's session can never be adopted by the next account
+/// on the same device — the cross-account contamination fixed on the web SDK in FRA-3280.
+final class SessionStorageTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var storage: UserDefaultsSessionStorage!
+    private let suiteName = "SessionStorageTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        storage = UserDefaultsSessionStorage(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testSessionsAreIsolatedPerAccount() {
+        storage.set("fps_a", accountId: "acc_a")
+        storage.set("fps_b", accountId: "acc_b")
+
+        XCTAssertEqual(storage.get(accountId: "acc_a"), "fps_a")
+        XCTAssertEqual(storage.get(accountId: "acc_b"), "fps_b")
+    }
+
+    /// The A→B regression: account B must never read account A's session.
+    func testOneAccountsSessionIsNotVisibleToAnother() {
+        storage.set("fps_a", accountId: "acc_a")
+
+        XCTAssertNil(storage.get(accountId: "acc_b"))
+    }
+
+    /// A session stored for an account must not leak into the pre-account slot, or the next account
+    /// on this device would adopt it.
+    func testAccountSessionIsNotWrittenToTheLegacySlot() {
+        storage.set("fps_a", accountId: "acc_a")
+
+        XCTAssertNil(storage.get(accountId: nil))
+        XCTAssertNil(defaults.string(forKey: UserDefaultsSessionStorage.legacyKey))
+    }
+
+    /// A session created before an account was known lives in the legacy slot, which is what makes
+    /// it adoptable later.
+    func testPreAccountSessionUsesTheLegacyKey() {
+        storage.set("fps_legacy", accountId: nil)
+
+        XCTAssertEqual(storage.get(accountId: nil), "fps_legacy")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsSessionStorage.legacyKey), "fps_legacy")
+    }
+
+    /// A session persisted by an older SDK build must still be readable after upgrade, so an
+    /// in-flight session survives rather than being silently abandoned.
+    func testSessionWrittenByAnOlderBuildIsStillReadable() {
+        defaults.set("fps_from_old_build", forKey: UserDefaultsSessionStorage.legacyKey)
+
+        XCTAssertEqual(storage.get(accountId: nil), "fps_from_old_build")
+    }
+
+    func testClearingAnAccountLeavesOtherAccountsIntact() {
+        storage.set("fps_a", accountId: "acc_a")
+        storage.set("fps_b", accountId: "acc_b")
+
+        storage.clear(accountId: "acc_a")
+
+        XCTAssertNil(storage.get(accountId: "acc_a"))
+        XCTAssertEqual(storage.get(accountId: "acc_b"), "fps_b")
+    }
+
+    func testRefreshTimestampIsTrackedPerAccount() {
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        storage.setLastRefresh(stamp, accountId: "acc_a")
+
+        XCTAssertEqual(storage.lastRefresh(accountId: "acc_a"), stamp)
+        XCTAssertNil(storage.lastRefresh(accountId: "acc_b"))
+    }
+
+    func testClearingAnAccountAlsoDropsItsRefreshTimestamp() {
+        storage.set("fps_a", accountId: "acc_a")
+        storage.setLastRefresh(Date(), accountId: "acc_a")
+
+        storage.clear(accountId: "acc_a")
+
+        XCTAssertNil(storage.lastRefresh(accountId: "acc_a"))
+    }
+}
+
+// MARK: - Transfer encoding
+
+/// The API accepts `sonar_session_id` only on charge-backed transfers and rejects it on payouts, so
+/// the field must never be attached to a transfer that has no source payment method.
+final class TransferSonarSessionTests: XCTestCase {
+
+    private func encode(_ request: TransferRequests.CreateTransferRequest) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(request)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    func testChargeBackedTransferEncodesTheSonarSession() throws {
+        var request = TransferRequests.CreateTransferRequest(amount: 5000,
+                                                             accountId: "acc_1",
+                                                             sourcePaymentMethodId: "pm_1")
+        request.sonarSessionId = "fps_1"
+
+        XCTAssertEqual(try encode(request)["sonar_session_id"] as? String, "fps_1")
+    }
+
+    /// Sending the field on a payout would turn a working transfer into a 400.
+    func testPayoutTransferOmitsTheSonarSessionEntirely() throws {
+        let request = TransferRequests.CreateTransferRequest(amount: 5000,
+                                                             accountId: "acc_1",
+                                                             destinationPaymentMethodId: "pm_1")
+
+        XCTAssertNil(try encode(request)["sonar_session_id"])
+    }
+}
+
+// MARK: - Error copy
+
+/// The server reports these rejections as bare codes; shown verbatim they read as
+/// "Error: sonar_session_required", which is what merchants reported.
+final class RiskErrorMessageTests: XCTestCase {
+
+    private func toast(forServerMessage message: String) -> String {
+        NetworkingError.serverError(statusCode: 422,
+                                    errorDescription: #"{"error":"\#(message)"}"#).toastMessage()
+    }
+
+    func testSonarSessionRequiredIsTranslatedForShoppers() {
+        let message = toast(forServerMessage: "sonar_session_required")
+
+        XCTAssertFalse(message.contains("sonar_session_required"))
+        XCTAssertEqual(message, "Error: We couldn't verify this device. Please try again.")
+    }
+
+    func testGeoComplianceCodesAreTranslatedForShoppers() {
+        XCTAssertFalse(toast(forServerMessage: "geo_compliance_blocked").contains("geo_compliance"))
+        XCTAssertFalse(toast(forServerMessage: "geo_compliance_vpn_detected").contains("geo_compliance"))
+    }
+
+    /// Server messages that are already human must be passed through untouched.
+    func testUnrecognisedServerMessagesArePassedThrough() {
+        XCTAssertEqual(toast(forServerMessage: "Card submitted is not a test card"),
+                       "Error: Card submitted is not a test card")
+    }
+}


### PR DESCRIPTION
Merchants with geo-compliance enabled were seeing "Error: sonar_session_required" when trying to check out. The error is a backend rejection, not an SDK string: the server resolves a payment's Sonar session through the Frame account, and it only associates a session with an account when the session create/update call sends an `account_id` — which the SDK never did. Every session it minted was account-less, invisible to risk checks, and every payment against it was rejected. This sends `account_id`, and keys stored sessions per account rather than under a single global key, since one account's session was otherwise adopted by the next account on the same device (the same contamination fixed on the web SDK in FRA-3280). 

Session setup was also fire-and-forget with errors swallowed into a `print()`, so checkout could outrun SDK start-up and fail with no diagnostic; it now goes through an awaitable `ensureSession(accountId:)` that callers await before charging, which coalesces concurrent callers onto one round trip, bounds the Fingerprint lookup, and refreshes a session before the server's freshness window expires. Transfers now carry `sonar_session_id`, but only when charge-backed — the API rejects that field on payouts, so attaching it unconditionally would have turned working payouts into 400s. Finally, the risk and geo-compliance codes are translated into copy a shopper can act on instead of being shown verbatim.

