### PR TITLE
CI: Run tests and podspec lint on 3.x pull requests

### DIFF
--- a/.github/workflows/podspec-lint.yml
+++ b/.github/workflows/podspec-lint.yml
@@ -2,12 +2,12 @@ name: Podspec Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 3.x ]
     paths:
       - '**.podspec'
       - '.github/workflows/podspec-lint.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, 3.x ]
     paths:
       - '**.podspec'
       - '.github/workflows/podspec-lint.yml'

--- a/.github/workflows/podspec-lint.yml
+++ b/.github/workflows/podspec-lint.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   lint:
-    runs-on: macos-latest
+    # Pinned: macos-latest has rolled to macos-26, which ships only Xcode 26.x. macos-15 is the
+    # newest image still carrying the Xcode 16.4 this SDK builds against.
+    runs-on: macos-15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: Frame Package Test (iOS)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 3.x ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 3.x ]
 
 jobs:
   test:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    # Pinned: macos-latest has rolled to macos-26, which ships only Xcode 26.x. macos-15 is the
+    # newest image still carrying the Xcode 16.4 this SDK builds against.
+    runs-on: macos-15
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The test and podspec-lint workflows only triggered on `main`, but `3.x` is where the released SDK is actually developed — which meant the PRs that ship to merchants (#63, #64, and now #65) were merging with no automated verification at all. This adds `3.x` to the `push` and `pull_request` branch filters on both workflows. Note that for `pull_request`, GitHub evaluates the workflow definition from the *base* branch rather than the PR head, so this has to land on `3.x` before any PR targeting it will start reporting checks — including #65, which is currently showing none. `docc.yml` needs no change; it triggers on version tags, which are already cut from `3.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)