### PR TITLE
FRA-5764 iOS: Standalone add-payment-method and add-payout-method screens

### DIFF
--- a/FrameExample-iOS/FrameExample-iOS/ContentView.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentView.swift
@@ -21,6 +21,9 @@ struct ContentView: View {
     @Environment(\.frameTheme) var theme
 
     @State var showCheckoutView: Bool = false
+    @State var showAddPaymentMethodView: Bool = false
+    @State var showAddBankAccountView: Bool = false
+    
     @State var showCustomersView: Bool = false
     @State var showPaymentMethodsView: Bool = false
     @State var showSubscriptionsView: Bool = false
@@ -31,7 +34,7 @@ struct ContentView: View {
     @State var applePayResult: String? = nil
 
     // Replace with an accountID from your dashboard.
-    var accountId: String = "ENTER_AN_ACCOUNT_ID"
+    var accountId: String = "83f5c9f7-7dfe-4962-8ccd-92a0fbc1909e"
     
     var body: some View {
         VStack {
@@ -44,7 +47,10 @@ struct ContentView: View {
                 .padding()
             ScrollView {
                 cartButton
+                addPaymentMethodButton
+                addBankAccountButton
                 onboardingButton
+                
                 // Apple Pay button — only visible on devices that support Apple Pay
                 FrameApplePayButton(
                     mode: .charge(amount: 35000, currency: "usd"),
@@ -121,6 +127,14 @@ struct ContentView: View {
             })
                 .presentationDragIndicator(.visible)
         }
+        .sheet(isPresented: $showAddPaymentMethodView, content: {
+            FrameAddPaymentMethodView(accountId: accountId)
+                .presentationDragIndicator(.visible)
+        })
+        .sheet(isPresented: $showAddBankAccountView, content: {
+            FrameAddPayoutMethodView(accountId: accountId)
+                .presentationDragIndicator(.visible)
+        })
         .sheet(isPresented: $showCustomersView) {
             customersScrollView
                 .presentationDragIndicator(.visible)
@@ -306,6 +320,38 @@ struct ContentView: View {
             self.showCheckoutView = true
         } label: {
             Text("Show Cart/Checkout")
+                .font(.headline)
+                .foregroundColor(theme.colors.primaryButtonText)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .frame(height: 45.0)
+        .frame(maxWidth: .infinity)
+        .background(theme.colors.primaryButton)
+        .cornerRadius(10.0)
+        .padding([.horizontal, .bottom])
+    }
+    
+    var addPaymentMethodButton: some View {
+        Button {
+            self.showAddPaymentMethodView = true
+        } label: {
+            Text("Add New Payment Method")
+                .font(.headline)
+                .foregroundColor(theme.colors.primaryButtonText)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .frame(height: 45.0)
+        .frame(maxWidth: .infinity)
+        .background(theme.colors.primaryButton)
+        .cornerRadius(10.0)
+        .padding([.horizontal, .bottom])
+    }
+    
+    var addBankAccountButton: some View {
+        Button {
+            self.showAddBankAccountView = true
+        } label: {
+            Text("Add New Bank Account")
                 .font(.headline)
                 .foregroundColor(theme.colors.primaryButtonText)
                 .frame(maxWidth: .infinity, alignment: .center)

--- a/FrameExample-iOS/FrameExample-iOS/ContentView.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
     @State var applePayResult: String? = nil
 
     // Replace with an accountID from your dashboard.
-    var accountId: String = "83f5c9f7-7dfe-4962-8ccd-92a0fbc1909e"
+    var accountId: String = "ENTER_AN_ACCOUNT_ID"
     
     var body: some View {
         VStack {

--- a/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
@@ -28,8 +28,8 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
         // grant full merchant privileges and must not ship in an app binary — serve sk_ from your
         // backend. This example sets a secret key only to exercise the legacy server-side demo
         // calls below; production apps should omit it.
-        FrameNetworking.shared.initialize(publishableKey: "ENTER_PUBLISHABLE_KEY_HERE",
-                                          secretKey: "ENTER_SECRET_KEY_HERE",
+        FrameNetworking.shared.initialize(publishableKey: "pk_sandbox_YLkjssgv9FMYKnfs3sfuTLQa",
+                                          secretKey: "sk_sandbox_UgLVWB47FrscWdjEvtGvZkm3",
 //                                          theme: FrameTheme(
 //                                              colors: .init(primaryButton: .purple, error: .orange),
 //                                              fonts: .init(title: .custom("Avenir-Black", size: 28)),

--- a/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
+++ b/FrameExample-iOS/FrameExample-iOS/ContentViewModel.swift
@@ -28,8 +28,8 @@ class ContentViewModel: ObservableObject, @unchecked Sendable {
         // grant full merchant privileges and must not ship in an app binary — serve sk_ from your
         // backend. This example sets a secret key only to exercise the legacy server-side demo
         // calls below; production apps should omit it.
-        FrameNetworking.shared.initialize(publishableKey: "pk_sandbox_YLkjssgv9FMYKnfs3sfuTLQa",
-                                          secretKey: "sk_sandbox_UgLVWB47FrscWdjEvtGvZkm3",
+        FrameNetworking.shared.initialize(publishableKey: "ENTER_PUBLISHABLE_KEY_HERE",
+                                          secretKey: "ENTER_SECRET_KEY_HERE",
 //                                          theme: FrameTheme(
 //                                              colors: .init(primaryButton: .purple, error: .orange),
 //                                              fonts: .init(title: .custom("Avenir-Black", size: 28)),

--- a/Sources/FrameOnboarding/ViewModels/OnboardingContainerViewModel.swift
+++ b/Sources/FrameOnboarding/ViewModels/OnboardingContainerViewModel.swift
@@ -389,7 +389,7 @@ class OnboardingContainerViewModel: ObservableObject {
 
     // Update an existing payment method with a billing address
     func updatePaymentMethod() async {
-        guard let paymentMethodId = selectedPayoutMethod?.id else { return }
+        guard let paymentMethodId = selectedPaymentMethod?.id else { return }
         guard beginAction() else { return }
         defer { endAction() }
 

--- a/Sources/FrameOnboarding/Views/Payments/FrameAddPaymentMethodView.swift
+++ b/Sources/FrameOnboarding/Views/Payments/FrameAddPaymentMethodView.swift
@@ -1,0 +1,86 @@
+//
+//  FrameAddPaymentMethodView.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 8/9/26.
+//
+
+import SwiftUI
+import Frame
+
+/// A standalone "add a payment method" screen that can be presented outside the onboarding flow.
+///
+/// Use this when a merchant wants to prompt an existing user to add a card at an arbitrary point in
+/// their app, rather than as a step inside ``OnboardingContainerView``. The screen presents the same
+/// card, billing-address, and Apple Pay inputs used during onboarding.
+///
+/// ```swift
+/// .sheet(isPresented: $showAddCard) {
+///     FrameAddPaymentMethodView(clientSecret: secret, accountId: accountId) { result in
+///         if case .completed(let id) = result { /* refresh payment methods */ }
+///     }
+/// }
+/// ```
+public struct FrameAddPaymentMethodView: View {
+    @StateObject private var viewModel: OnboardingContainerViewModel
+    private let onResult: (FrameResult) -> Void
+    private let onboardingClientSecret: String?
+
+    /// Guards against emitting `.cancelled` on dismiss when a method was already added.
+    @State private var didFinish: Bool = false
+
+    /// Creates a standalone add-payment-method screen.
+    ///
+    /// - Parameters:
+    ///   - clientSecret: The onboarding-session token (`onb_sess_…`) minted by your server
+    ///     (`POST /v1/onboarding_sessions`) and handed to your app. While this screen is presented
+    ///     every request authenticates with this token, scoping it to a single account. Pass `nil`
+    ///     only for legacy integrations that still authenticate with a secret key.
+    ///   - accountId: The Frame account ID the new payment method is attached to.
+    ///   - onResult: Closure called with a ``FrameResult`` when the screen finishes or is cancelled.
+    public init(clientSecret: String? = nil,
+                accountId: String,
+                onResult: @escaping (FrameResult) -> Void = { _ in }) {
+        self.onboardingClientSecret = clientSecret
+        self.onResult = onResult
+        self._viewModel = StateObject(wrappedValue: OnboardingContainerViewModel(accountId: accountId,
+                                                                                 requiredCapabilities: []))
+    }
+
+    /// The wrapped onboarding add-payment-method screen, bound to a session and result callback.
+    public var body: some View {
+        // Present standalone only — ``OnboardingContainerView`` already applies these two.
+        AddPaymentMethodView(onboardingContainerViewModel: viewModel,
+                             onlyAddressVerification: false)
+            .keyboardDoneToolbar()
+            .frameToastOverlay()
+            .onAppear {
+                if let onboardingClientSecret {
+                    FrameNetworking.shared.beginOnboardingSession(clientSecret: onboardingClientSecret)
+                }
+            }
+            .onChange(of: viewModel.selectedPaymentMethod?.id) { _, newValue in
+                guard let newValue, !didFinish else { return }
+                didFinish = true
+                onResult(.completed(id: newValue))
+            }
+            .onDisappear {
+                // The Apple Pay sheet covering this view fires .onDisappear without the user
+                // dismissing us; it runs inside beginAction()/endAction(), so this distinguishes them.
+                guard !viewModel.isPerformingAction else { return }
+
+                // Only clear a session this view began, so we don't wipe another flow's.
+                if onboardingClientSecret != nil {
+                    FrameNetworking.shared.endOnboardingSession()
+                }
+                if !didFinish {
+                    didFinish = true
+                    onResult(.cancelled)
+                }
+            }
+    }
+}
+
+#Preview {
+    FrameAddPaymentMethodView(accountId: "")
+}

--- a/Sources/FrameOnboarding/Views/Payments/FrameAddPayoutMethodView.swift
+++ b/Sources/FrameOnboarding/Views/Payments/FrameAddPayoutMethodView.swift
@@ -1,0 +1,86 @@
+//
+//  FrameAddPayoutMethodView.swift
+//  Frame-iOS
+//
+//  Created by Frame Payments on 8/9/26.
+//
+
+import SwiftUI
+import Frame
+
+/// A standalone "add a payout bank account" screen that can be presented outside the onboarding flow.
+///
+/// Use this when a merchant wants to prompt an existing user to add a payout account at an arbitrary
+/// point in their app, rather than as a step inside ``OnboardingContainerView``. The screen offers
+/// the same Plaid Link connection and manual routing/account entry used during onboarding.
+///
+/// ```swift
+/// .sheet(isPresented: $showAddBank) {
+///     FrameAddPayoutMethodView(clientSecret: secret, accountId: accountId) { result in
+///         if case .completed(let id) = result { /* refresh payout methods */ }
+///     }
+/// }
+/// ```
+public struct FrameAddPayoutMethodView: View {
+    @StateObject private var viewModel: OnboardingContainerViewModel
+    private let onResult: (FrameResult) -> Void
+    private let onboardingClientSecret: String?
+
+    /// Guards against emitting `.cancelled` on dismiss when an account was already added.
+    @State private var didFinish: Bool = false
+
+    /// Creates a standalone add-payout-method screen.
+    ///
+    /// - Parameters:
+    ///   - clientSecret: The onboarding-session token (`onb_sess_…`) minted by your server
+    ///     (`POST /v1/onboarding_sessions`) and handed to your app. While this screen is presented
+    ///     every request authenticates with this token, scoping it to a single account. Pass `nil`
+    ///     only for legacy integrations that still authenticate with a secret key.
+    ///   - accountId: The Frame account ID the new payout method is attached to. Required — Plaid
+    ///     Link cannot be opened without it.
+    ///   - onResult: Closure called with a ``FrameResult`` when the screen finishes or is cancelled.
+    public init(clientSecret: String? = nil,
+                accountId: String,
+                onResult: @escaping (FrameResult) -> Void = { _ in }) {
+        self.onboardingClientSecret = clientSecret
+        self.onResult = onResult
+        self._viewModel = StateObject(wrappedValue: OnboardingContainerViewModel(accountId: accountId,
+                                                                                 requiredCapabilities: []))
+    }
+
+    /// The wrapped onboarding add-payout-method screen, bound to a session and result callback.
+    public var body: some View {
+        // Present standalone only — ``OnboardingContainerView`` already applies these two.
+        AddPayoutMethodView(onboardingContainerViewModel: viewModel)
+            .keyboardDoneToolbar()
+            .frameToastOverlay()
+            .onAppear {
+                if let onboardingClientSecret {
+                    FrameNetworking.shared.beginOnboardingSession(clientSecret: onboardingClientSecret)
+                }
+            }
+            .onChange(of: viewModel.selectedPayoutMethod?.id) { _, newValue in
+                guard let newValue, !didFinish else { return }
+                didFinish = true
+                onResult(.completed(id: newValue))
+            }
+            .onDisappear {
+                // Plaid Link covering this view fires .onDisappear without the user dismissing us;
+                // Plaid runs inside beginAction()/endAction(), so this distinguishes them.
+                guard !viewModel.isPerformingAction else { return }
+
+                // Only clear a session this view began, so we don't wipe another flow's.
+                if onboardingClientSecret != nil {
+                    FrameNetworking.shared.endOnboardingSession()
+                }
+                if !didFinish {
+                    didFinish = true
+                    onResult(.cancelled)
+                }
+            }
+    }
+}
+
+#Preview {
+    FrameAddPayoutMethodView(accountId: "")
+}


### PR DESCRIPTION
Closes [FRA-5764](https://linear.app/framepayments/issue/FRA-5764/ios-standalone-add-payment-method-and-add-payout-method-entry-points)

## What

Merchants can now prompt a user to add a payment method or a payout bank account at any point in their app, without running the whole onboarding flow. Two new public views:

```swift
FrameAddPaymentMethodView(clientSecret: secret, accountId: accountId) { result in
    if case .completed(let id) = result { /* refresh payment methods */ }
}

FrameAddPayoutMethodView(clientSecret: secret, accountId: accountId) { result in
    if case .completed(let id) = result { /* refresh payout methods */ }
}
```

## How

These are **thin wrappers**, not new screens. Each one owns a private `OnboardingContainerViewModel` and delegates the entire UI to the existing internal `AddPaymentMethodView` / `AddPayoutMethodView`. No card input, billing address, Plaid, or ACH logic is duplicated — that all still lives in exactly one place, so there's nothing to drift.

The wrappers only exist to solve three things that blocked standalone use:

1. Both underlying views are `internal`, so merchants can't reference them (nor construct the `OnboardingContainerViewModel` argument).
2. They rely on `@Environment(\.dismiss)`, which assumes a host presented them. Standalone, success and cancel were indistinguishable — both just called `dismiss()`.
3. Results were written to view-model properties and then cleared by `clearAccountDetails()`, so a caller got no handle on what was created.

Why wrappers rather than making the existing views public: that would expose the whole 755-line `OnboardingContainerViewModel` as public API and push session management onto the caller. The wrapper keeps that surface private.

Two deviations from the original plan, both decided mid-implementation:

- **Uses the SDK's existing `FrameResult`**, not a new `Result<PaymentMethod, Error>`. `OnboardingContainerView` already uses `onResult: (FrameResult) -> Void`; a second convention in the same SDK isn't worth it. Tradeoff: the callback hands back an id string rather than the full `PaymentMethod`.
- **Added a `clientSecret` parameter.** Without it, standalone requests fall back to the configured key instead of an onboarding session — wrong for a merchant-facing entry point. Mirrors `OnboardingContainerView`.

## Testing

Gates run locally, all passing:

- SwiftLint (`missing_docs`) — both new files linted, no errors.
- Dark-mode lint (hardcoded color literals) — passes.
- `xcodebuild` of `FrameExample-iOS` for iOS Simulator, which links `FrameOnboarding` — builds, and I confirmed `FrameAddPaymentMethodView.o` / `FrameAddPayoutMethodView.o` were actually produced rather than trusting the success line.

**Not done:**

- **No unit tests added.** `Frame-iOSTests` only covers the `Frame` target; there's no existing test coverage for onboarding screens to extend, and these wrappers are almost entirely SwiftUI lifecycle wiring.
- **Not exercised against a live account.** The end-to-end paths worth manual QA before merge: card add, Apple Pay add, Plaid connect, and manual ACH entry — each confirming `.completed(id:)` fires with the right id and that cancel yields `.cancelled`.
